### PR TITLE
object: Add request type and `Type` function in `Request` interface

### DIFF
--- a/object/service.go
+++ b/object/service.go
@@ -28,12 +28,13 @@ type (
 	Token = session.Token
 
 	// Request defines object rpc requests.
-	// All object operations must have TTL, Epoch, Container ID and
+	// All object operations must have TTL, Epoch, Type, Container ID and
 	// permission of usage previous network map.
 	Request interface {
 		service.MetaHeader
 
 		CID() CID
+		Type() RequestType
 		AllowPreviousNetMap() bool
 	}
 )
@@ -169,3 +170,24 @@ func (m *GetRangeRequest) AllowPreviousNetMap() bool { return false }
 
 // AllowPreviousNetMap returns permission to use previous network map in object get range hash request.
 func (m *GetRangeHashRequest) AllowPreviousNetMap() bool { return false }
+
+// Type returns type of the object put request.
+func (m *PutRequest) Type() RequestType { return RequestPut }
+
+// Type returns type of the object get request.
+func (m *GetRequest) Type() RequestType { return RequestGet }
+
+// Type returns type of the object head request.
+func (m *HeadRequest) Type() RequestType { return RequestHead }
+
+// Type returns type of the object search request.
+func (m *SearchRequest) Type() RequestType { return RequestSearch }
+
+// Type returns type of the object delete request.
+func (m *DeleteRequest) Type() RequestType { return RequestDelete }
+
+// Type returns type of the object get range request.
+func (m *GetRangeRequest) Type() RequestType { return RequestRange }
+
+// Type returns type of the object get range hash request.
+func (m *GetRangeHashRequest) Type() RequestType { return RequestRangeHash }

--- a/object/service_test.go
+++ b/object/service_test.go
@@ -18,11 +18,22 @@ func TestRequest(t *testing.T) {
 		&GetRangeHashRequest{},
 	}
 
+	types := []RequestType{
+		RequestPut,
+		RequestGet,
+		RequestHead,
+		RequestSearch,
+		RequestDelete,
+		RequestRange,
+		RequestRangeHash,
+	}
+
 	for i := range cases {
 		v := cases[i]
 
 		t.Run(fmt.Sprintf("%T", v), func(t *testing.T) {
 			require.NotPanics(t, func() { v.CID() })
+			require.Equal(t, types[i], v.Type())
 		})
 	}
 }

--- a/object/types.go
+++ b/object/types.go
@@ -28,7 +28,10 @@ type (
 		PRead(ctx context.Context, addr refs.Address, rng Range) ([]byte, error)
 	}
 
-	headerType int
+	// RequestType of the object service requests.
+	RequestType int
+
+	headerType  int
 )
 
 const (
@@ -71,11 +74,51 @@ const (
 	PublicKeyHdr
 )
 
+const (
+	_ RequestType = iota
+	// RequestPut is a type for object put request.
+	RequestPut
+	// RequestGet is a type for object get request.
+	RequestGet
+	// RequestHead is a type for object head request.
+	RequestHead
+	// RequestSearch is a type for object search request.
+	RequestSearch
+	// RequestRange is a type for object range request.
+	RequestRange
+	// RequestRangeHash is a type for object hash range request.
+	RequestRangeHash
+	// RequestDelete is a type for object delete request.
+	RequestDelete
+)
+
 var (
 	_ internal.Custom = (*Object)(nil)
 
 	emptyObject = new(Object).Bytes()
 )
+
+// String returns printable name of the request type.
+func (s RequestType) String() string {
+	switch s {
+	case RequestPut:
+		return "PUT"
+	case RequestGet:
+		return "GET"
+	case RequestHead:
+		return "HEAD"
+	case RequestSearch:
+		return "SEARCH"
+	case RequestRange:
+		return "RANGE"
+	case RequestRangeHash:
+		return "RANGE_HASH"
+	case RequestDelete:
+		return "DELETE"
+	default:
+		return "UNKNOWN"
+	}
+}
 
 // Bytes returns marshaled object in a binary format.
 func (m Object) Bytes() []byte { data, _ := m.Marshal(); return data }


### PR DESCRIPTION
`BasicACL` have set of rules for every request type. ACL will be processed before any request specific handlers. Therefore we need to determine request type in generic `Request` interface, which is used in pre-processors of object service implementation.

For now `requestType` is a private type in object service implementation. 