### PR TITLE
session: add OwnerID to a private token storage key

### DIFF
--- a/session/private.go
+++ b/session/private.go
@@ -43,3 +43,13 @@ func (t *pToken) PublicKey() []byte {
 func (t *pToken) Expired(epoch uint64) bool {
 	return t.validUntil < epoch
 }
+
+// SetOwnerID is an owner ID field setter.
+func (s *PrivateTokenKey) SetOwnerID(id OwnerID) {
+	s.owner = id
+}
+
+// SetTokenID is a token ID field setter.
+func (s *PrivateTokenKey) SetTokenID(id TokenID) {
+	s.token = id
+}

--- a/session/private_test.go
+++ b/session/private_test.go
@@ -48,3 +48,23 @@ func TestPToken_Expired(t *testing.T) {
 	// must be expired in the epoch after last
 	require.True(t, token.Expired(e+1))
 }
+
+func TestPrivateTokenKey_SetOwnerID(t *testing.T) {
+	ownerID := OwnerID{1, 2, 3}
+
+	s := new(PrivateTokenKey)
+
+	s.SetOwnerID(ownerID)
+
+	require.Equal(t, ownerID, s.owner)
+}
+
+func TestPrivateTokenKey_SetTokenID(t *testing.T) {
+	tokenID := TokenID{1, 2, 3}
+
+	s := new(PrivateTokenKey)
+
+	s.SetTokenID(tokenID)
+
+	require.Equal(t, tokenID, s.token)
+}

--- a/session/store.go
+++ b/session/store.go
@@ -7,7 +7,7 @@ import (
 type mapTokenStore struct {
 	*sync.RWMutex
 
-	tokens map[TokenID]PrivateToken
+	tokens map[PrivateTokenKey]PrivateToken
 }
 
 // NewMapTokenStore creates new PrivateTokenStore instance.
@@ -16,16 +16,16 @@ type mapTokenStore struct {
 func NewMapTokenStore() PrivateTokenStore {
 	return &mapTokenStore{
 		RWMutex: new(sync.RWMutex),
-		tokens:  make(map[TokenID]PrivateToken),
+		tokens:  make(map[PrivateTokenKey]PrivateToken),
 	}
 }
 
 // Store adds passed token to the map.
 //
 // Resulting error is always nil.
-func (s *mapTokenStore) Store(id TokenID, token PrivateToken) error {
+func (s *mapTokenStore) Store(key PrivateTokenKey, token PrivateToken) error {
 	s.Lock()
-	s.tokens[id] = token
+	s.tokens[key] = token
 	s.Unlock()
 
 	return nil
@@ -34,11 +34,11 @@ func (s *mapTokenStore) Store(id TokenID, token PrivateToken) error {
 // Fetch returns the map element corresponding to the given key.
 //
 // Returns ErrPrivateTokenNotFound is there is no element in map.
-func (s *mapTokenStore) Fetch(id TokenID) (PrivateToken, error) {
+func (s *mapTokenStore) Fetch(key PrivateTokenKey) (PrivateToken, error) {
 	s.RLock()
 	defer s.RUnlock()
 
-	t, ok := s.tokens[id]
+	t, ok := s.tokens[key]
 	if !ok {
 		return nil, ErrPrivateTokenNotFound
 	}

--- a/session/types.go
+++ b/session/types.go
@@ -23,12 +23,18 @@ type PrivateToken interface {
 	Expired(uint64) bool
 }
 
+// PrivateTokenKey is a structure of private token storage key.
+type PrivateTokenKey struct {
+	owner OwnerID
+	token TokenID
+}
+
 // PrivateTokenSource is an interface of private token storage with read access.
 type PrivateTokenSource interface {
 	// Fetch must return the storage record corresponding to the passed key.
 	//
 	// Resulting error must be ErrPrivateTokenNotFound if there is no corresponding record.
-	Fetch(TokenID) (PrivateToken, error)
+	Fetch(PrivateTokenKey) (PrivateToken, error)
 }
 
 // EpochLifetimeStore is an interface of the storage of elements that lifetime is limited by NeoFS epoch.
@@ -45,7 +51,7 @@ type PrivateTokenStore interface {
 	// Store must save passed private token in the storage under the given key.
 	//
 	// Resulting error must be nil if private token was stored successfully.
-	Store(TokenID, PrivateToken) error
+	Store(PrivateTokenKey, PrivateToken) error
 }
 
 // KeyStore is an interface of the storage of public keys addressable by OwnerID,


### PR DESCRIPTION
In previous implementation PrivateTokenStore was not stored an OwnerID of the session. It is necessary to store the identifier of the owner of the token to verify ownership.