### PR TITLE
object: add Token header case to CopyTo

### DIFF
--- a/object/types.go
+++ b/object/types.go
@@ -251,6 +251,12 @@ func (m *Object) CopyTo(o *Object) {
 					HomoHash: v.HomoHash,
 				},
 			}
+		case *Header_Token:
+			o.Headers[i] = Header{
+				Value: &Header_Token{
+					Token: v.Token,
+				},
+			}
 		default:
 			o.Headers[i] = *proto.Clone(&m.Headers[i]).(*Header)
 		}

--- a/object/types_test.go
+++ b/object/types_test.go
@@ -178,3 +178,24 @@ Object:
 	require.NoError(t, Stringify(buf, obj))
 	require.Equal(t, res, buf.String())
 }
+
+func TestObject_Copy(t *testing.T) {
+	t.Run("token header", func(t *testing.T) {
+		token := new(Token)
+		token.SetID(service.TokenID{1, 2, 3})
+
+		obj := new(Object)
+
+		obj.AddHeader(&Header{
+			Value: &Header_Token{
+				Token: token,
+			},
+		})
+
+		cp := obj.Copy()
+
+		_, h := cp.LastHeader(HeaderType(TokenHdr))
+		require.NotNil(t, h)
+		require.Equal(t, token, h.GetValue().(*Header_Token).Token)
+	})
+}


### PR DESCRIPTION
Fixes `proto: don't know how to copy` message. 