### PR TITLE
Implement SignedDataSource on all request messages

### DIFF
--- a/accounting/sign.go
+++ b/accounting/sign.go
@@ -3,17 +3,13 @@ package accounting
 import (
 	"encoding/binary"
 	"io"
+
+	"github.com/nspcc-dev/neofs-api-go/service"
 )
 
 // SignedData returns payload bytes of the request.
 func (m BalanceRequest) SignedData() ([]byte, error) {
-	data := make([]byte, m.SignedDataSize())
-
-	if _, err := m.ReadSignedData(data); err != nil {
-		return nil, err
-	}
-
-	return data, nil
+	return service.SignedDataFromReader(m)
 }
 
 // SignedDataSize returns payload size of the request.
@@ -37,13 +33,7 @@ func (m BalanceRequest) ReadSignedData(p []byte) (int, error) {
 
 // SignedData returns payload bytes of the request.
 func (m GetRequest) SignedData() ([]byte, error) {
-	data := make([]byte, m.SignedDataSize())
-
-	if _, err := m.ReadSignedData(data); err != nil {
-		return nil, err
-	}
-
-	return data, nil
+	return service.SignedDataFromReader(m)
 }
 
 // SignedDataSize returns payload size of the request.
@@ -71,13 +61,7 @@ func (m GetRequest) ReadSignedData(p []byte) (int, error) {
 
 // SignedData returns payload bytes of the request.
 func (m PutRequest) SignedData() ([]byte, error) {
-	data := make([]byte, m.SignedDataSize())
-
-	if _, err := m.ReadSignedData(data); err != nil {
-		return nil, err
-	}
-
-	return data, nil
+	return service.SignedDataFromReader(m)
 }
 
 // SignedDataSize returns payload size of the request.
@@ -125,13 +109,7 @@ func (m PutRequest) ReadSignedData(p []byte) (int, error) {
 
 // SignedData returns payload bytes of the request.
 func (m ListRequest) SignedData() ([]byte, error) {
-	data := make([]byte, m.SignedDataSize())
-
-	if _, err := m.ReadSignedData(data); err != nil {
-		return nil, err
-	}
-
-	return data, nil
+	return service.SignedDataFromReader(m)
 }
 
 // SignedDataSize returns payload size of the request.
@@ -155,13 +133,7 @@ func (m ListRequest) ReadSignedData(p []byte) (int, error) {
 
 // SignedData returns payload bytes of the request.
 func (m DeleteRequest) SignedData() ([]byte, error) {
-	data := make([]byte, m.SignedDataSize())
-
-	if _, err := m.ReadSignedData(data); err != nil {
-		return nil, err
-	}
-
-	return data, nil
+	return service.SignedDataFromReader(m)
 }
 
 // SignedDataSize returns payload size of the request.

--- a/accounting/sign.go
+++ b/accounting/sign.go
@@ -31,3 +31,37 @@ func (m BalanceRequest) ReadSignedData(p []byte) (int, error) {
 
 	return sz, nil
 }
+
+// SignedData returns payload bytes of the request.
+func (m GetRequest) SignedData() ([]byte, error) {
+	data := make([]byte, m.SignedDataSize())
+
+	if _, err := m.ReadSignedData(data); err != nil {
+		return nil, err
+	}
+
+	return data, nil
+}
+
+// SignedDataSize returns payload size of the request.
+func (m GetRequest) SignedDataSize() int {
+	return m.GetID().Size() + m.GetOwnerID().Size()
+}
+
+// ReadSignedData copies payload bytes to passed buffer.
+//
+// If the buffer size is insufficient, io.ErrUnexpectedEOF returns.
+func (m GetRequest) ReadSignedData(p []byte) (int, error) {
+	sz := m.SignedDataSize()
+	if len(p) < sz {
+		return 0, io.ErrUnexpectedEOF
+	}
+
+	var off int
+
+	off += copy(p[off:], m.GetID().Bytes())
+
+	copy(p[off:], m.GetOwnerID().Bytes())
+
+	return sz, nil
+}

--- a/accounting/sign.go
+++ b/accounting/sign.go
@@ -152,3 +152,41 @@ func (m ListRequest) ReadSignedData(p []byte) (int, error) {
 
 	return sz, nil
 }
+
+// SignedData returns payload bytes of the request.
+func (m DeleteRequest) SignedData() ([]byte, error) {
+	data := make([]byte, m.SignedDataSize())
+
+	if _, err := m.ReadSignedData(data); err != nil {
+		return nil, err
+	}
+
+	return data, nil
+}
+
+// SignedDataSize returns payload size of the request.
+func (m DeleteRequest) SignedDataSize() int {
+	return 0 +
+		m.GetID().Size() +
+		m.GetOwnerID().Size() +
+		m.GetMessageID().Size()
+}
+
+// ReadSignedData copies payload bytes to passed buffer.
+//
+// If the buffer size is insufficient, io.ErrUnexpectedEOF returns.
+func (m DeleteRequest) ReadSignedData(p []byte) (int, error) {
+	if len(p) < m.SignedDataSize() {
+		return 0, io.ErrUnexpectedEOF
+	}
+
+	var off int
+
+	off += copy(p[off:], m.GetID().Bytes())
+
+	off += copy(p[off:], m.GetOwnerID().Bytes())
+
+	off += copy(p[off:], m.GetMessageID().Bytes())
+
+	return off, nil
+}

--- a/accounting/sign.go
+++ b/accounting/sign.go
@@ -1,0 +1,33 @@
+package accounting
+
+import "io"
+
+// SignedData returns payload bytes of the request.
+func (m BalanceRequest) SignedData() ([]byte, error) {
+	data := make([]byte, m.SignedDataSize())
+
+	if _, err := m.ReadSignedData(data); err != nil {
+		return nil, err
+	}
+
+	return data, nil
+}
+
+// SignedDataSize returns payload size of the request.
+func (m BalanceRequest) SignedDataSize() int {
+	return m.GetOwnerID().Size()
+}
+
+// ReadSignedData copies payload bytes to passed buffer.
+//
+// If the buffer size is insufficient, io.ErrUnexpectedEOF returns.
+func (m BalanceRequest) ReadSignedData(p []byte) (int, error) {
+	sz := m.SignedDataSize()
+	if len(p) < sz {
+		return 0, io.ErrUnexpectedEOF
+	}
+
+	copy(p, m.GetOwnerID().Bytes())
+
+	return sz, nil
+}

--- a/accounting/sign.go
+++ b/accounting/sign.go
@@ -122,3 +122,33 @@ func (m PutRequest) ReadSignedData(p []byte) (int, error) {
 
 	return off, nil
 }
+
+// SignedData returns payload bytes of the request.
+func (m ListRequest) SignedData() ([]byte, error) {
+	data := make([]byte, m.SignedDataSize())
+
+	if _, err := m.ReadSignedData(data); err != nil {
+		return nil, err
+	}
+
+	return data, nil
+}
+
+// SignedDataSize returns payload size of the request.
+func (m ListRequest) SignedDataSize() int {
+	return m.GetOwnerID().Size()
+}
+
+// ReadSignedData copies payload bytes to passed buffer.
+//
+// If the buffer size is insufficient, io.ErrUnexpectedEOF returns.
+func (m ListRequest) ReadSignedData(p []byte) (int, error) {
+	sz := m.SignedDataSize()
+	if len(p) < sz {
+		return 0, io.ErrUnexpectedEOF
+	}
+
+	copy(p, m.GetOwnerID().Bytes())
+
+	return sz, nil
+}

--- a/accounting/sign.go
+++ b/accounting/sign.go
@@ -165,11 +165,14 @@ func (m DeleteRequest) SignedData() ([]byte, error) {
 }
 
 // SignedDataSize returns payload size of the request.
-func (m DeleteRequest) SignedDataSize() int {
-	return 0 +
-		m.GetID().Size() +
-		m.GetOwnerID().Size() +
-		m.GetMessageID().Size()
+func (m DeleteRequest) SignedDataSize() (sz int) {
+	sz += m.GetID().Size()
+
+	sz += m.GetOwnerID().Size()
+
+	sz += m.GetMessageID().Size()
+
+	return
 }
 
 // ReadSignedData copies payload bytes to passed buffer.

--- a/accounting/sign.go
+++ b/accounting/sign.go
@@ -1,6 +1,9 @@
 package accounting
 
-import "io"
+import (
+	"encoding/binary"
+	"io"
+)
 
 // SignedData returns payload bytes of the request.
 func (m BalanceRequest) SignedData() ([]byte, error) {
@@ -64,4 +67,58 @@ func (m GetRequest) ReadSignedData(p []byte) (int, error) {
 	copy(p[off:], m.GetOwnerID().Bytes())
 
 	return sz, nil
+}
+
+// SignedData returns payload bytes of the request.
+func (m PutRequest) SignedData() ([]byte, error) {
+	data := make([]byte, m.SignedDataSize())
+
+	if _, err := m.ReadSignedData(data); err != nil {
+		return nil, err
+	}
+
+	return data, nil
+}
+
+// SignedDataSize returns payload size of the request.
+func (m PutRequest) SignedDataSize() (sz int) {
+	sz += m.GetOwnerID().Size()
+
+	sz += m.GetMessageID().Size()
+
+	sz += 8
+
+	if amount := m.GetAmount(); amount != nil {
+		sz += amount.Size()
+	}
+
+	return
+}
+
+// ReadSignedData copies payload bytes to passed buffer.
+//
+// If the buffer size is insufficient, io.ErrUnexpectedEOF returns.
+func (m PutRequest) ReadSignedData(p []byte) (int, error) {
+	if len(p) < m.SignedDataSize() {
+		return 0, io.ErrUnexpectedEOF
+	}
+
+	var off int
+
+	off += copy(p[off:], m.GetOwnerID().Bytes())
+
+	off += copy(p[off:], m.GetMessageID().Bytes())
+
+	binary.BigEndian.PutUint64(p[off:], m.GetHeight())
+	off += 8
+
+	if amount := m.GetAmount(); amount != nil {
+		n, err := amount.MarshalTo(p[off:])
+		off += n
+		if err != nil {
+			return off + n, err
+		}
+	}
+
+	return off, nil
 }

--- a/accounting/sign_test.go
+++ b/accounting/sign_test.go
@@ -1,0 +1,54 @@
+package accounting
+
+import (
+	"testing"
+
+	"github.com/nspcc-dev/neofs-api-go/service"
+	"github.com/nspcc-dev/neofs-crypto/test"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSignBalanceRequest(t *testing.T) {
+	// create test OwnerID
+	ownerID := OwnerID{1, 2, 3}
+
+	// create test BalanceRequest
+	req := new(BalanceRequest)
+	req.SetOwnerID(ownerID)
+
+	// create test private key
+	sk := test.DecodeKey(0)
+
+	items := []struct {
+		corrupt func()
+		restore func()
+	}{
+		{
+			corrupt: func() {
+				ownerID[0]++
+				req.SetOwnerID(ownerID)
+			},
+			restore: func() {
+				ownerID[0]--
+				req.SetOwnerID(ownerID)
+			},
+		},
+	}
+
+	for _, item := range items {
+		// sign with private key
+		require.NoError(t, service.AddSignatureWithKey(sk, req))
+
+		// ascertain that verification is passed
+		require.NoError(t, service.VerifyAccumulatedSignatures(req))
+
+		// corrupt the request
+		item.corrupt()
+
+		// ascertain that verification is failed
+		require.Error(t, service.VerifyAccumulatedSignatures(req))
+
+		// ascertain that request
+		item.restore()
+	}
+}

--- a/accounting/sign_test.go
+++ b/accounting/sign_test.go
@@ -104,6 +104,21 @@ func TestSignBalanceRequest(t *testing.T) {
 				},
 			},
 		},
+		{ // ListRequest
+			constructor: func() sigType {
+				return new(ListRequest)
+			},
+			payloadCorrupt: []func(sigType){
+				func(s sigType) {
+					req := s.(*ListRequest)
+
+					owner := req.GetOwnerID()
+					owner[0]++
+
+					req.SetOwnerID(owner)
+				},
+			},
+		},
 	}
 
 	for _, item := range items {

--- a/accounting/sign_test.go
+++ b/accounting/sign_test.go
@@ -119,6 +119,37 @@ func TestSignBalanceRequest(t *testing.T) {
 				},
 			},
 		},
+		{
+			constructor: func() sigType {
+				return new(DeleteRequest)
+			},
+			payloadCorrupt: []func(sigType){
+				func(s sigType) {
+					req := s.(*DeleteRequest)
+
+					id, err := NewChequeID()
+					require.NoError(t, err)
+
+					req.SetID(id)
+				},
+				func(s sigType) {
+					req := s.(*DeleteRequest)
+
+					owner := req.GetOwnerID()
+					owner[0]++
+
+					req.SetOwnerID(owner)
+				},
+				func(s sigType) {
+					req := s.(*DeleteRequest)
+
+					mid := req.GetMessageID()
+					mid[0]++
+
+					req.SetMessageID(mid)
+				},
+			},
+		},
 	}
 
 	for _, item := range items {

--- a/accounting/sign_test.go
+++ b/accounting/sign_test.go
@@ -3,6 +3,7 @@ package accounting
 import (
 	"testing"
 
+	"github.com/nspcc-dev/neofs-api-go/decimal"
 	"github.com/nspcc-dev/neofs-api-go/service"
 	"github.com/nspcc-dev/neofs-crypto/test"
 	"github.com/stretchr/testify/require"
@@ -57,6 +58,49 @@ func TestSignBalanceRequest(t *testing.T) {
 					id[0]++
 
 					req.SetOwnerID(id)
+				},
+			},
+		},
+		{ // PutRequest
+			constructor: func() sigType {
+				req := new(PutRequest)
+
+				amount := decimal.New(1)
+				req.SetAmount(amount)
+
+				return req
+			},
+			payloadCorrupt: []func(sigType){
+				func(s sigType) {
+					req := s.(*PutRequest)
+
+					owner := req.GetOwnerID()
+					owner[0]++
+
+					req.SetOwnerID(owner)
+				},
+				func(s sigType) {
+					req := s.(*PutRequest)
+
+					mid := req.GetMessageID()
+					mid[0]++
+
+					req.SetMessageID(mid)
+				},
+				func(s sigType) {
+					req := s.(*PutRequest)
+
+					req.SetHeight(req.GetHeight() + 1)
+				},
+				func(s sigType) {
+					req := s.(*PutRequest)
+
+					amount := req.GetAmount()
+					if amount == nil {
+						req.SetAmount(decimal.New(0))
+					} else {
+						req.SetAmount(amount.Add(decimal.New(amount.GetValue())))
+					}
 				},
 			},
 		},

--- a/accounting/types.go
+++ b/accounting/types.go
@@ -361,3 +361,23 @@ func (m BalanceRequest) GetOwnerID() OwnerID {
 func (m *BalanceRequest) SetOwnerID(owner OwnerID) {
 	m.OwnerID = owner
 }
+
+// GetID is an ID field getter.
+func (m GetRequest) GetID() ChequeID {
+	return m.ID
+}
+
+// SetID is an ID field setter.
+func (m *GetRequest) SetID(id ChequeID) {
+	m.ID = id
+}
+
+// GetOwnerID is an OwnerID field getter.
+func (m GetRequest) GetOwnerID() OwnerID {
+	return m.OwnerID
+}
+
+// SetOwnerID is an OwnerID field setter.
+func (m *GetRequest) SetOwnerID(id OwnerID) {
+	m.OwnerID = id
+}

--- a/accounting/types.go
+++ b/accounting/types.go
@@ -351,3 +351,13 @@ func (m *Settlement) Equal(s *Settlement) bool {
 	}
 	return len(m.Transactions) == 0 || reflect.DeepEqual(m.Transactions, s.Transactions)
 }
+
+// GetOwnerID is an OwnerID field getter.
+func (m BalanceRequest) GetOwnerID() OwnerID {
+	return m.OwnerID
+}
+
+// SetOwnerID is an OwnerID field setter.
+func (m *BalanceRequest) SetOwnerID(owner OwnerID) {
+	m.OwnerID = owner
+}

--- a/accounting/types.go
+++ b/accounting/types.go
@@ -411,3 +411,13 @@ func (m *PutRequest) SetAmount(amount *decimal.Decimal) {
 func (m *PutRequest) SetHeight(h uint64) {
 	m.Height = h
 }
+
+// GetOwnerID is an OwnerID field getter.
+func (m ListRequest) GetOwnerID() OwnerID {
+	return m.OwnerID
+}
+
+// SetOwnerID is an OwnerID field setter.
+func (m *ListRequest) SetOwnerID(id OwnerID) {
+	m.OwnerID = id
+}

--- a/accounting/types.go
+++ b/accounting/types.go
@@ -381,3 +381,33 @@ func (m GetRequest) GetOwnerID() OwnerID {
 func (m *GetRequest) SetOwnerID(id OwnerID) {
 	m.OwnerID = id
 }
+
+// GetOwnerID is an OwnerID field getter.
+func (m PutRequest) GetOwnerID() OwnerID {
+	return m.OwnerID
+}
+
+// SetOwnerID is an OwnerID field setter.
+func (m *PutRequest) SetOwnerID(id OwnerID) {
+	m.OwnerID = id
+}
+
+// GetMessageID is a MessageID field getter.
+func (m PutRequest) GetMessageID() MessageID {
+	return m.MessageID
+}
+
+// SetMessageID is a MessageID field setter.
+func (m *PutRequest) SetMessageID(id MessageID) {
+	m.MessageID = id
+}
+
+// SetAmount is an Amount field setter.
+func (m *PutRequest) SetAmount(amount *decimal.Decimal) {
+	m.Amount = amount
+}
+
+// SetHeight is a Height field setter.
+func (m *PutRequest) SetHeight(h uint64) {
+	m.Height = h
+}

--- a/accounting/types.go
+++ b/accounting/types.go
@@ -421,3 +421,33 @@ func (m ListRequest) GetOwnerID() OwnerID {
 func (m *ListRequest) SetOwnerID(id OwnerID) {
 	m.OwnerID = id
 }
+
+// GetID is an ID field getter.
+func (m DeleteRequest) GetID() ChequeID {
+	return m.ID
+}
+
+// SetID is an ID field setter.
+func (m *DeleteRequest) SetID(id ChequeID) {
+	m.ID = id
+}
+
+// GetOwnerID is an OwnerID field getter.
+func (m DeleteRequest) GetOwnerID() OwnerID {
+	return m.OwnerID
+}
+
+// SetOwnerID is an OwnerID field setter.
+func (m *DeleteRequest) SetOwnerID(id OwnerID) {
+	m.OwnerID = id
+}
+
+// GetMessageID is a MessageID field getter.
+func (m DeleteRequest) GetMessageID() MessageID {
+	return m.MessageID
+}
+
+// SetMessageID is a MessageID field setter.
+func (m *DeleteRequest) SetMessageID(id MessageID) {
+	m.MessageID = id
+}

--- a/accounting/types_test.go
+++ b/accounting/types_test.go
@@ -84,3 +84,12 @@ func TestCheque(t *testing.T) {
 		require.Equal(t, cheque.Amount, decimal.NewGAS(42))
 	})
 }
+
+func TestBalanceRequest_SetOwnerID(t *testing.T) {
+	ownerID := OwnerID{1, 2, 3}
+	m := new(BalanceRequest)
+
+	m.SetOwnerID(ownerID)
+
+	require.Equal(t, ownerID, m.GetOwnerID())
+}

--- a/accounting/types_test.go
+++ b/accounting/types_test.go
@@ -161,3 +161,33 @@ func TestListRequestGettersSetters(t *testing.T) {
 
 	require.Equal(t, ownerID, m.GetOwnerID())
 }
+
+func TestDeleteRequestGettersSetters(t *testing.T) {
+	t.Run("id", func(t *testing.T) {
+		id := ChequeID("test id")
+		m := new(DeleteRequest)
+
+		m.SetID(id)
+
+		require.Equal(t, id, m.GetID())
+	})
+
+	t.Run("owner", func(t *testing.T) {
+		id := OwnerID{1, 2, 3}
+		m := new(DeleteRequest)
+
+		m.SetOwnerID(id)
+
+		require.Equal(t, id, m.GetOwnerID())
+	})
+
+	t.Run("message ID", func(t *testing.T) {
+		id, err := refs.NewUUID()
+		require.NoError(t, err)
+
+		m := new(DeleteRequest)
+		m.SetMessageID(id)
+
+		require.Equal(t, id, m.GetMessageID())
+	})
+}

--- a/accounting/types_test.go
+++ b/accounting/types_test.go
@@ -152,3 +152,12 @@ func TestPutRequestGettersSetters(t *testing.T) {
 		require.Equal(t, h, m.GetHeight())
 	})
 }
+
+func TestListRequestGettersSetters(t *testing.T) {
+	ownerID := OwnerID{1, 2, 3}
+	m := new(ListRequest)
+
+	m.SetOwnerID(ownerID)
+
+	require.Equal(t, ownerID, m.GetOwnerID())
+}

--- a/accounting/types_test.go
+++ b/accounting/types_test.go
@@ -93,3 +93,23 @@ func TestBalanceRequest_SetOwnerID(t *testing.T) {
 
 	require.Equal(t, ownerID, m.GetOwnerID())
 }
+
+func TestGetRequestGettersSetters(t *testing.T) {
+	t.Run("id", func(t *testing.T) {
+		id := ChequeID("test id")
+		m := new(GetRequest)
+
+		m.SetID(id)
+
+		require.Equal(t, id, m.GetID())
+	})
+
+	t.Run("owner", func(t *testing.T) {
+		id := OwnerID{1, 2, 3}
+		m := new(GetRequest)
+
+		m.SetOwnerID(id)
+
+		require.Equal(t, id, m.GetOwnerID())
+	})
+}

--- a/accounting/types_test.go
+++ b/accounting/types_test.go
@@ -113,3 +113,42 @@ func TestGetRequestGettersSetters(t *testing.T) {
 		require.Equal(t, id, m.GetOwnerID())
 	})
 }
+
+func TestPutRequestGettersSetters(t *testing.T) {
+	t.Run("owner", func(t *testing.T) {
+		id := OwnerID{1, 2, 3}
+		m := new(PutRequest)
+
+		m.SetOwnerID(id)
+
+		require.Equal(t, id, m.GetOwnerID())
+	})
+
+	t.Run("message ID", func(t *testing.T) {
+		id, err := refs.NewUUID()
+		require.NoError(t, err)
+
+		m := new(PutRequest)
+		m.SetMessageID(id)
+
+		require.Equal(t, id, m.GetMessageID())
+	})
+
+	t.Run("amount", func(t *testing.T) {
+		amount := decimal.New(1)
+		m := new(PutRequest)
+
+		m.SetAmount(amount)
+
+		require.Equal(t, amount, m.GetAmount())
+	})
+
+	t.Run("height", func(t *testing.T) {
+		h := uint64(3)
+		m := new(PutRequest)
+
+		m.SetHeight(h)
+
+		require.Equal(t, h, m.GetHeight())
+	})
+}

--- a/bootstrap/sign.go
+++ b/bootstrap/sign.go
@@ -1,0 +1,48 @@
+package bootstrap
+
+import "io"
+
+// SignedData returns payload bytes of the request.
+func (m Request) SignedData() ([]byte, error) {
+	data := make([]byte, m.SignedDataSize())
+
+	if _, err := m.ReadSignedData(data); err != nil {
+		return nil, err
+	}
+
+	return data, nil
+}
+
+// SignedDataSize returns payload size of the request.
+func (m Request) SignedDataSize() (sz int) {
+	sz += m.GetType().Size()
+
+	sz += m.GetState().Size()
+
+	info := m.GetInfo()
+	sz += info.Size()
+
+	return
+}
+
+// ReadSignedData copies payload bytes to passed buffer.
+//
+// If the Request size is insufficient, io.ErrUnexpectedEOF returns.
+func (m Request) ReadSignedData(p []byte) (int, error) {
+	if len(p) < m.SignedDataSize() {
+		return 0, io.ErrUnexpectedEOF
+	}
+
+	var off int
+
+	off += copy(p[off:], m.GetType().Bytes())
+
+	off += copy(p[off:], m.GetState().Bytes())
+
+	info := m.GetInfo()
+	// FIXME: implement and use stable functions
+	n, err := info.MarshalTo(p[off:])
+	off += n
+
+	return off, err
+}

--- a/bootstrap/sign.go
+++ b/bootstrap/sign.go
@@ -1,16 +1,14 @@
 package bootstrap
 
-import "io"
+import (
+	"io"
+
+	"github.com/nspcc-dev/neofs-api-go/service"
+)
 
 // SignedData returns payload bytes of the request.
 func (m Request) SignedData() ([]byte, error) {
-	data := make([]byte, m.SignedDataSize())
-
-	if _, err := m.ReadSignedData(data); err != nil {
-		return nil, err
-	}
-
-	return data, nil
+	return service.SignedDataFromReader(m)
 }
 
 // SignedDataSize returns payload size of the request.

--- a/bootstrap/sign_test.go
+++ b/bootstrap/sign_test.go
@@ -1,0 +1,82 @@
+package bootstrap
+
+import (
+	"testing"
+
+	"github.com/nspcc-dev/neofs-api-go/service"
+	"github.com/nspcc-dev/neofs-crypto/test"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRequestSign(t *testing.T) {
+	sk := test.DecodeKey(0)
+
+	type sigType interface {
+		service.SignedDataWithToken
+		service.SignKeyPairAccumulator
+		service.SignKeyPairSource
+		SetToken(*service.Token)
+	}
+
+	items := []struct {
+		constructor    func() sigType
+		payloadCorrupt []func(sigType)
+	}{
+		{ // Request
+			constructor: func() sigType {
+				return new(Request)
+			},
+			payloadCorrupt: []func(sigType){
+				func(s sigType) {
+					req := s.(*Request)
+
+					req.SetType(req.GetType() + 1)
+				},
+				func(s sigType) {
+					req := s.(*Request)
+
+					req.SetState(req.GetState() + 1)
+				},
+				func(s sigType) {
+					req := s.(*Request)
+
+					info := req.GetInfo()
+					info.Address += "1"
+
+					req.SetInfo(info)
+				},
+			},
+		},
+	}
+
+	for _, item := range items {
+		{ // token corruptions
+			v := item.constructor()
+
+			token := new(service.Token)
+			v.SetToken(token)
+
+			require.NoError(t, service.SignDataWithSessionToken(sk, v))
+
+			require.NoError(t, service.VerifyAccumulatedSignaturesWithToken(v))
+
+			token.SetSessionKey(append(token.GetSessionKey(), 1))
+
+			require.Error(t, service.VerifyAccumulatedSignaturesWithToken(v))
+		}
+
+		{ // payload corruptions
+			for _, corruption := range item.payloadCorrupt {
+				v := item.constructor()
+
+				require.NoError(t, service.SignDataWithSessionToken(sk, v))
+
+				require.NoError(t, service.VerifyAccumulatedSignaturesWithToken(v))
+
+				corruption(v)
+
+				require.Error(t, service.VerifyAccumulatedSignaturesWithToken(v))
+			}
+		}
+	}
+}

--- a/bootstrap/types.go
+++ b/bootstrap/types.go
@@ -122,10 +122,12 @@ func (m *Request) SetInfo(info NodeInfo) {
 	m.Info = info
 }
 
+// Size returns the size necessary for a binary representation of the state.
 func (x Request_State) Size() int {
 	return 4
 }
 
+// Bytes returns a binary representation of the state.
 func (x Request_State) Bytes() []byte {
 	data := make([]byte, x.Size())
 

--- a/bootstrap/types.go
+++ b/bootstrap/types.go
@@ -2,6 +2,7 @@ package bootstrap
 
 import (
 	"bytes"
+	"encoding/binary"
 	"encoding/hex"
 	"strconv"
 	"strings"
@@ -26,6 +27,8 @@ var (
 	_ proto.Message = (*NodeInfo)(nil)
 	_ proto.Message = (*SpreadMap)(nil)
 )
+
+var requestEndianness = binary.BigEndian
 
 // Equals checks whether two NodeInfo has same address.
 func (m NodeInfo) Equals(n1 NodeInfo) bool {
@@ -97,4 +100,36 @@ func (m SpreadMap) String() string {
 		"Epoch: " + strconv.FormatUint(m.Epoch, 10) +
 		", " +
 		"Netmap: [" + strings.Join(result, ",") + "]>"
+}
+
+// GetType is a Type field getter.
+func (m Request) GetType() NodeType {
+	return m.Type
+}
+
+// SetType is a Type field setter.
+func (m *Request) SetType(t NodeType) {
+	m.Type = t
+}
+
+// SetState is a State field setter.
+func (m *Request) SetState(state Request_State) {
+	m.State = state
+}
+
+// SetInfo is an Info field getter.
+func (m *Request) SetInfo(info NodeInfo) {
+	m.Info = info
+}
+
+func (x Request_State) Size() int {
+	return 4
+}
+
+func (x Request_State) Bytes() []byte {
+	data := make([]byte, x.Size())
+
+	requestEndianness.PutUint32(data, uint32(x))
+
+	return data
 }

--- a/bootstrap/types_test.go
+++ b/bootstrap/types_test.go
@@ -1,0 +1,39 @@
+package bootstrap
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRequestGettersSetters(t *testing.T) {
+	t.Run("type", func(t *testing.T) {
+		rt := NodeType(1)
+		m := new(Request)
+
+		m.SetType(rt)
+
+		require.Equal(t, rt, m.GetType())
+	})
+
+	t.Run("state", func(t *testing.T) {
+		st := Request_State(1)
+		m := new(Request)
+
+		m.SetState(st)
+
+		require.Equal(t, st, m.GetState())
+	})
+
+	t.Run("info", func(t *testing.T) {
+		info := NodeInfo{
+			Address: "some address",
+		}
+
+		m := new(Request)
+
+		m.SetInfo(info)
+
+		require.Equal(t, info, m.GetInfo())
+	})
+}

--- a/container/sign.go
+++ b/container/sign.go
@@ -95,3 +95,34 @@ func (m DeleteRequest) ReadSignedData(p []byte) (int, error) {
 
 	return off, nil
 }
+
+// SignedData returns payload bytes of the request.
+func (m GetRequest) SignedData() ([]byte, error) {
+	data := make([]byte, m.SignedDataSize())
+
+	if _, err := m.ReadSignedData(data); err != nil {
+		return nil, err
+	}
+
+	return data, nil
+}
+
+// SignedDataSize returns payload size of the request.
+func (m GetRequest) SignedDataSize() (sz int) {
+	return m.GetCID().Size()
+}
+
+// ReadSignedData copies payload bytes to passed buffer.
+//
+// If the Request size is insufficient, io.ErrUnexpectedEOF returns.
+func (m GetRequest) ReadSignedData(p []byte) (int, error) {
+	if len(p) < m.SignedDataSize() {
+		return 0, io.ErrUnexpectedEOF
+	}
+
+	var off int
+
+	off += copy(p[off:], m.GetCID().Bytes())
+
+	return off, nil
+}

--- a/container/sign.go
+++ b/container/sign.go
@@ -77,7 +77,7 @@ func (m DeleteRequest) SignedData() ([]byte, error) {
 }
 
 // SignedDataSize returns payload size of the request.
-func (m DeleteRequest) SignedDataSize() (sz int) {
+func (m DeleteRequest) SignedDataSize() int {
 	return m.GetCID().Size()
 }
 
@@ -108,7 +108,7 @@ func (m GetRequest) SignedData() ([]byte, error) {
 }
 
 // SignedDataSize returns payload size of the request.
-func (m GetRequest) SignedDataSize() (sz int) {
+func (m GetRequest) SignedDataSize() int {
 	return m.GetCID().Size()
 }
 
@@ -123,6 +123,37 @@ func (m GetRequest) ReadSignedData(p []byte) (int, error) {
 	var off int
 
 	off += copy(p[off:], m.GetCID().Bytes())
+
+	return off, nil
+}
+
+// SignedData returns payload bytes of the request.
+func (m ListRequest) SignedData() ([]byte, error) {
+	data := make([]byte, m.SignedDataSize())
+
+	if _, err := m.ReadSignedData(data); err != nil {
+		return nil, err
+	}
+
+	return data, nil
+}
+
+// SignedDataSize returns payload size of the request.
+func (m ListRequest) SignedDataSize() int {
+	return m.GetOwnerID().Size()
+}
+
+// ReadSignedData copies payload bytes to passed buffer.
+//
+// If the Request size is insufficient, io.ErrUnexpectedEOF returns.
+func (m ListRequest) ReadSignedData(p []byte) (int, error) {
+	if len(p) < m.SignedDataSize() {
+		return 0, io.ErrUnexpectedEOF
+	}
+
+	var off int
+
+	off += copy(p[off:], m.GetOwnerID().Bytes())
 
 	return off, nil
 }

--- a/container/sign.go
+++ b/container/sign.go
@@ -3,19 +3,15 @@ package container
 import (
 	"encoding/binary"
 	"io"
+
+	service "github.com/nspcc-dev/neofs-api-go/service"
 )
 
 var requestEndianness = binary.BigEndian
 
 // SignedData returns payload bytes of the request.
 func (m PutRequest) SignedData() ([]byte, error) {
-	data := make([]byte, m.SignedDataSize())
-
-	if _, err := m.ReadSignedData(data); err != nil {
-		return nil, err
-	}
-
-	return data, nil
+	return service.SignedDataFromReader(m)
 }
 
 // SignedDataSize returns payload size of the request.
@@ -67,13 +63,7 @@ func (m PutRequest) ReadSignedData(p []byte) (int, error) {
 
 // SignedData returns payload bytes of the request.
 func (m DeleteRequest) SignedData() ([]byte, error) {
-	data := make([]byte, m.SignedDataSize())
-
-	if _, err := m.ReadSignedData(data); err != nil {
-		return nil, err
-	}
-
-	return data, nil
+	return service.SignedDataFromReader(m)
 }
 
 // SignedDataSize returns payload size of the request.
@@ -98,13 +88,7 @@ func (m DeleteRequest) ReadSignedData(p []byte) (int, error) {
 
 // SignedData returns payload bytes of the request.
 func (m GetRequest) SignedData() ([]byte, error) {
-	data := make([]byte, m.SignedDataSize())
-
-	if _, err := m.ReadSignedData(data); err != nil {
-		return nil, err
-	}
-
-	return data, nil
+	return service.SignedDataFromReader(m)
 }
 
 // SignedDataSize returns payload size of the request.
@@ -129,13 +113,7 @@ func (m GetRequest) ReadSignedData(p []byte) (int, error) {
 
 // SignedData returns payload bytes of the request.
 func (m ListRequest) SignedData() ([]byte, error) {
-	data := make([]byte, m.SignedDataSize())
-
-	if _, err := m.ReadSignedData(data); err != nil {
-		return nil, err
-	}
-
-	return data, nil
+	return service.SignedDataFromReader(m)
 }
 
 // SignedDataSize returns payload size of the request.

--- a/container/sign.go
+++ b/container/sign.go
@@ -1,0 +1,66 @@
+package container
+
+import (
+	"encoding/binary"
+	"io"
+)
+
+var requestEndianness = binary.BigEndian
+
+// SignedData returns payload bytes of the request.
+func (m PutRequest) SignedData() ([]byte, error) {
+	data := make([]byte, m.SignedDataSize())
+
+	if _, err := m.ReadSignedData(data); err != nil {
+		return nil, err
+	}
+
+	return data, nil
+}
+
+// SignedDataSize returns payload size of the request.
+func (m PutRequest) SignedDataSize() (sz int) {
+	sz += m.GetMessageID().Size()
+
+	sz += 8
+
+	sz += m.GetOwnerID().Size()
+
+	rules := m.GetRules()
+	sz += rules.Size()
+
+	sz += 4
+
+	return
+}
+
+// ReadSignedData copies payload bytes to passed buffer.
+//
+// If the Request size is insufficient, io.ErrUnexpectedEOF returns.
+func (m PutRequest) ReadSignedData(p []byte) (int, error) {
+	if len(p) < m.SignedDataSize() {
+		return 0, io.ErrUnexpectedEOF
+	}
+
+	var off int
+
+	off += copy(p[off:], m.GetMessageID().Bytes())
+
+	requestEndianness.PutUint64(p[off:], m.GetCapacity())
+	off += 8
+
+	off += copy(p[off:], m.GetOwnerID().Bytes())
+
+	rules := m.GetRules()
+	// FIXME: implement and use stable functions
+	n, err := rules.MarshalTo(p[off:])
+	off += n
+	if err != nil {
+		return off, err
+	}
+
+	requestEndianness.PutUint32(p[off:], m.GetBasicACL())
+	off += 4
+
+	return off, nil
+}

--- a/container/sign.go
+++ b/container/sign.go
@@ -64,3 +64,34 @@ func (m PutRequest) ReadSignedData(p []byte) (int, error) {
 
 	return off, nil
 }
+
+// SignedData returns payload bytes of the request.
+func (m DeleteRequest) SignedData() ([]byte, error) {
+	data := make([]byte, m.SignedDataSize())
+
+	if _, err := m.ReadSignedData(data); err != nil {
+		return nil, err
+	}
+
+	return data, nil
+}
+
+// SignedDataSize returns payload size of the request.
+func (m DeleteRequest) SignedDataSize() (sz int) {
+	return m.GetCID().Size()
+}
+
+// ReadSignedData copies payload bytes to passed buffer.
+//
+// If the Request size is insufficient, io.ErrUnexpectedEOF returns.
+func (m DeleteRequest) ReadSignedData(p []byte) (int, error) {
+	if len(p) < m.SignedDataSize() {
+		return 0, io.ErrUnexpectedEOF
+	}
+
+	var off int
+
+	off += copy(p[off:], m.GetCID().Bytes())
+
+	return off, nil
+}

--- a/container/sign_test.go
+++ b/container/sign_test.go
@@ -78,6 +78,21 @@ func TestRequestSign(t *testing.T) {
 				},
 			},
 		},
+		{ // GetRequest
+			constructor: func() sigType {
+				return new(GetRequest)
+			},
+			payloadCorrupt: []func(sigType){
+				func(s sigType) {
+					req := s.(*GetRequest)
+
+					cid := req.GetCID()
+					cid[0]++
+
+					req.SetCID(cid)
+				},
+			},
+		},
 	}
 
 	for _, item := range items {

--- a/container/sign_test.go
+++ b/container/sign_test.go
@@ -1,0 +1,98 @@
+package container
+
+import (
+	"testing"
+
+	"github.com/nspcc-dev/neofs-api-go/service"
+	"github.com/nspcc-dev/neofs-crypto/test"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRequestSign(t *testing.T) {
+	sk := test.DecodeKey(0)
+
+	type sigType interface {
+		service.SignedDataWithToken
+		service.SignKeyPairAccumulator
+		service.SignKeyPairSource
+		SetToken(*service.Token)
+	}
+
+	items := []struct {
+		constructor    func() sigType
+		payloadCorrupt []func(sigType)
+	}{
+		{ // Request
+			constructor: func() sigType {
+				return new(PutRequest)
+			},
+			payloadCorrupt: []func(sigType){
+				func(s sigType) {
+					req := s.(*PutRequest)
+
+					id := req.GetMessageID()
+					id[0]++
+
+					req.SetMessageID(id)
+				},
+				func(s sigType) {
+					req := s.(*PutRequest)
+
+					req.SetCapacity(req.GetCapacity() + 1)
+				},
+				func(s sigType) {
+					req := s.(*PutRequest)
+
+					owner := req.GetOwnerID()
+					owner[0]++
+
+					req.SetOwnerID(owner)
+				},
+				func(s sigType) {
+					req := s.(*PutRequest)
+
+					rules := req.GetRules()
+					rules.ReplFactor++
+
+					req.SetRules(rules)
+				},
+				func(s sigType) {
+					req := s.(*PutRequest)
+
+					req.SetBasicACL(req.GetBasicACL() + 1)
+				},
+			},
+		},
+	}
+
+	for _, item := range items {
+		{ // token corruptions
+			v := item.constructor()
+
+			token := new(service.Token)
+			v.SetToken(token)
+
+			require.NoError(t, service.SignDataWithSessionToken(sk, v))
+
+			require.NoError(t, service.VerifyAccumulatedSignaturesWithToken(v))
+
+			token.SetSessionKey(append(token.GetSessionKey(), 1))
+
+			require.Error(t, service.VerifyAccumulatedSignaturesWithToken(v))
+		}
+
+		{ // payload corruptions
+			for _, corruption := range item.payloadCorrupt {
+				v := item.constructor()
+
+				require.NoError(t, service.SignDataWithSessionToken(sk, v))
+
+				require.NoError(t, service.VerifyAccumulatedSignaturesWithToken(v))
+
+				corruption(v)
+
+				require.Error(t, service.VerifyAccumulatedSignaturesWithToken(v))
+			}
+		}
+	}
+}

--- a/container/sign_test.go
+++ b/container/sign_test.go
@@ -22,7 +22,7 @@ func TestRequestSign(t *testing.T) {
 		constructor    func() sigType
 		payloadCorrupt []func(sigType)
 	}{
-		{ // Request
+		{ // PutRequest
 			constructor: func() sigType {
 				return new(PutRequest)
 			},
@@ -60,6 +60,21 @@ func TestRequestSign(t *testing.T) {
 					req := s.(*PutRequest)
 
 					req.SetBasicACL(req.GetBasicACL() + 1)
+				},
+			},
+		},
+		{ // DeleteRequest
+			constructor: func() sigType {
+				return new(DeleteRequest)
+			},
+			payloadCorrupt: []func(sigType){
+				func(s sigType) {
+					req := s.(*DeleteRequest)
+
+					cid := req.GetCID()
+					cid[0]++
+
+					req.SetCID(cid)
 				},
 			},
 		},

--- a/container/sign_test.go
+++ b/container/sign_test.go
@@ -93,6 +93,21 @@ func TestRequestSign(t *testing.T) {
 				},
 			},
 		},
+		{ // ListRequest
+			constructor: func() sigType {
+				return new(ListRequest)
+			},
+			payloadCorrupt: []func(sigType){
+				func(s sigType) {
+					req := s.(*ListRequest)
+
+					owner := req.GetOwnerID()
+					owner[0]++
+
+					req.SetOwnerID(owner)
+				},
+			},
+		},
 	}
 
 	for _, item := range items {

--- a/container/types.go
+++ b/container/types.go
@@ -148,3 +148,13 @@ func (m GetRequest) GetCID() CID {
 func (m *GetRequest) SetCID(cid CID) {
 	m.CID = cid
 }
+
+// GetOwnerID is an OwnerID field getter.
+func (m ListRequest) GetOwnerID() OwnerID {
+	return m.OwnerID
+}
+
+// SetOwnerID is an OwnerID field setter.
+func (m *ListRequest) SetOwnerID(owner OwnerID) {
+	m.OwnerID = owner
+}

--- a/container/types.go
+++ b/container/types.go
@@ -93,3 +93,38 @@ func NewTestContainer() (*Container, error) {
 		},
 	})
 }
+
+// GetMessageID is a MessageID field getter.
+func (m PutRequest) GetMessageID() MessageID {
+	return m.MessageID
+}
+
+// SetMessageID is a MessageID field getter.
+func (m *PutRequest) SetMessageID(id MessageID) {
+	m.MessageID = id
+}
+
+// SetCapacity is a Capacity field setter.
+func (m *PutRequest) SetCapacity(c uint64) {
+	m.Capacity = c
+}
+
+// GetOwnerID is an OwnerID field getter.
+func (m PutRequest) GetOwnerID() OwnerID {
+	return m.OwnerID
+}
+
+// SetOwnerID is an OwnerID field setter.
+func (m *PutRequest) SetOwnerID(owner OwnerID) {
+	m.OwnerID = owner
+}
+
+// SetRules is a Rules field setter.
+func (m *PutRequest) SetRules(rules netmap.PlacementRule) {
+	m.Rules = rules
+}
+
+// SetBasicACL is a BasicACL field setter.
+func (m *PutRequest) SetBasicACL(acl uint32) {
+	m.BasicACL = acl
+}

--- a/container/types.go
+++ b/container/types.go
@@ -128,3 +128,13 @@ func (m *PutRequest) SetRules(rules netmap.PlacementRule) {
 func (m *PutRequest) SetBasicACL(acl uint32) {
 	m.BasicACL = acl
 }
+
+// GetCID is a CID field getter.
+func (m DeleteRequest) GetCID() CID {
+	return m.CID
+}
+
+// SetCID is a CID field setter.
+func (m *DeleteRequest) SetCID(cid CID) {
+	m.CID = cid
+}

--- a/container/types.go
+++ b/container/types.go
@@ -138,3 +138,13 @@ func (m DeleteRequest) GetCID() CID {
 func (m *DeleteRequest) SetCID(cid CID) {
 	m.CID = cid
 }
+
+// GetCID is a CID field getter.
+func (m GetRequest) GetCID() CID {
+	return m.CID
+}
+
+// SetCID is a CID field setter.
+func (m *GetRequest) SetCID(cid CID) {
+	m.CID = cid
+}

--- a/container/types_test.go
+++ b/container/types_test.go
@@ -129,3 +129,14 @@ func TestGetRequestGettersSetters(t *testing.T) {
 		require.Equal(t, cid, m.GetCID())
 	})
 }
+
+func TestListRequestGettersSetters(t *testing.T) {
+	t.Run("owner", func(t *testing.T) {
+		owner := OwnerID{1, 2, 3}
+		m := new(PutRequest)
+
+		m.SetOwnerID(owner)
+
+		require.Equal(t, owner, m.GetOwnerID())
+	})
+}

--- a/container/types_test.go
+++ b/container/types_test.go
@@ -118,3 +118,14 @@ func TestDeleteRequestGettersSetters(t *testing.T) {
 		require.Equal(t, cid, m.GetCID())
 	})
 }
+
+func TestGetRequestGettersSetters(t *testing.T) {
+	t.Run("cid", func(t *testing.T) {
+		cid := CID{1, 2, 3}
+		m := new(GetRequest)
+
+		m.SetCID(cid)
+
+		require.Equal(t, cid, m.GetCID())
+	})
+}

--- a/container/types_test.go
+++ b/container/types_test.go
@@ -55,3 +55,55 @@ func TestCID(t *testing.T) {
 		require.Equal(t, cid1, cid2)
 	})
 }
+
+func TestPutRequestGettersSetters(t *testing.T) {
+	t.Run("owner", func(t *testing.T) {
+		owner := OwnerID{1, 2, 3}
+		m := new(PutRequest)
+
+		m.SetOwnerID(owner)
+
+		require.Equal(t, owner, m.GetOwnerID())
+	})
+
+	t.Run("capacity", func(t *testing.T) {
+		cp := uint64(3)
+		m := new(PutRequest)
+
+		m.SetCapacity(cp)
+
+		require.Equal(t, cp, m.GetCapacity())
+	})
+
+	t.Run("message ID", func(t *testing.T) {
+		id, err := refs.NewUUID()
+		require.NoError(t, err)
+
+		m := new(PutRequest)
+
+		m.SetMessageID(id)
+
+		require.Equal(t, id, m.GetMessageID())
+	})
+
+	t.Run("rules", func(t *testing.T) {
+		rules := netmap.PlacementRule{
+			ReplFactor: 1,
+		}
+
+		m := new(PutRequest)
+
+		m.SetRules(rules)
+
+		require.Equal(t, rules, m.GetRules())
+	})
+
+	t.Run("basic ACL", func(t *testing.T) {
+		bACL := uint32(5)
+		m := new(PutRequest)
+
+		m.SetBasicACL(bACL)
+
+		require.Equal(t, bACL, m.GetBasicACL())
+	})
+}

--- a/container/types_test.go
+++ b/container/types_test.go
@@ -107,3 +107,14 @@ func TestPutRequestGettersSetters(t *testing.T) {
 		require.Equal(t, bACL, m.GetBasicACL())
 	})
 }
+
+func TestDeleteRequestGettersSetters(t *testing.T) {
+	t.Run("cid", func(t *testing.T) {
+		cid := CID{1, 2, 3}
+		m := new(DeleteRequest)
+
+		m.SetCID(cid)
+
+		require.Equal(t, cid, m.GetCID())
+	})
+}

--- a/service/errors.go
+++ b/service/errors.go
@@ -43,3 +43,7 @@ const ErrNilDataWithTokenSignAccumulator = internal.Error("signed data with toke
 // ErrNilSignatureKeySourceWithToken is returned by functions that expect
 // a non-nil SignatureKeySourceWithToken, but received nil.
 const ErrNilSignatureKeySourceWithToken = internal.Error("key-signature source with token is nil")
+
+// ErrNilSignedDataReader is returned by functions that expect
+// a non-nil SignedDataReader, but received nil.
+const ErrNilSignedDataReader = internal.Error("signed data reader is nil")

--- a/service/role.go
+++ b/service/role.go
@@ -1,5 +1,7 @@
 package service
 
+import "encoding/binary"
+
 const (
 	_ NodeRole = iota
 	// InnerRingNode that work like IR node.
@@ -18,4 +20,16 @@ func (nt NodeRole) String() string {
 	default:
 		return "Unknown"
 	}
+}
+
+func (nt NodeRole) Size() int {
+	return 4
+}
+
+func (nt NodeRole) Bytes() []byte {
+	data := make([]byte, nt.Size())
+
+	binary.BigEndian.PutUint32(data, uint32(nt))
+
+	return data
 }

--- a/service/role.go
+++ b/service/role.go
@@ -22,10 +22,12 @@ func (nt NodeRole) String() string {
 	}
 }
 
+// Size returns the size necessary for a binary representation of the NodeRole.
 func (nt NodeRole) Size() int {
 	return 4
 }
 
+// Bytes returns a binary representation of the NodeRole.
 func (nt NodeRole) Bytes() []byte {
 	data := make([]byte, nt.Size())
 

--- a/service/token.go
+++ b/service/token.go
@@ -123,11 +123,7 @@ func (m *Token) AddSignKey(sig []byte, _ *ecdsa.PublicKey) {
 
 // SignedData returns token information in a binary representation.
 func (m *Token) SignedData() ([]byte, error) {
-	data := make([]byte, m.SignedDataSize())
-
-	copyTokenSignedData(data, m)
-
-	return data, nil
+	return SignedDataFromReader(m)
 }
 
 // ReadSignedData copies a binary representation of the token information to passed buffer.

--- a/service/utils.go
+++ b/service/utils.go
@@ -1,0 +1,18 @@
+package service
+
+// SignedDataFromReader allocates buffer and reads bytes from passed reader to it.
+//
+// If passed SignedDataReader is nil, ErrNilSignedDataReader returns.
+func SignedDataFromReader(r SignedDataReader) ([]byte, error) {
+	if r == nil {
+		return nil, ErrNilSignedDataReader
+	}
+
+	data := make([]byte, r.SignedDataSize())
+
+	if _, err := r.ReadSignedData(data); err != nil {
+		return nil, err
+	}
+
+	return data, nil
+}

--- a/service/utils_test.go
+++ b/service/utils_test.go
@@ -1,0 +1,34 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSignedDataFromReader(t *testing.T) {
+	// nil SignedDataReader
+	_, err := SignedDataFromReader(nil)
+	require.EqualError(t, err, ErrNilSignedDataReader.Error())
+
+	rdr := &testSignedDataReader{
+		testSignedDataSrc: new(testSignedDataSrc),
+	}
+
+	// make reader to return an error
+	rdr.err = errors.New("test error")
+
+	_, err = SignedDataFromReader(rdr)
+	require.EqualError(t, err, rdr.err.Error())
+
+	// remove the error
+	rdr.err = nil
+
+	// fill the data
+	rdr.data = testData(t, 10)
+
+	res, err := SignedDataFromReader(rdr)
+	require.NoError(t, err)
+	require.Equal(t, rdr.data, res)
+}

--- a/session/request.go
+++ b/session/request.go
@@ -5,6 +5,7 @@ import (
 	"io"
 
 	"github.com/nspcc-dev/neofs-api-go/refs"
+	"github.com/nspcc-dev/neofs-api-go/service"
 )
 
 const signedRequestDataSize = 0 +
@@ -31,14 +32,7 @@ func (m *CreateRequest) SetOwnerID(id OwnerID) {
 
 // SignedData returns payload bytes of the request.
 func (m CreateRequest) SignedData() ([]byte, error) {
-	data := make([]byte, m.SignedDataSize())
-
-	_, err := m.ReadSignedData(data)
-	if err != nil {
-		return nil, err
-	}
-
-	return data, nil
+	return service.SignedDataFromReader(m)
 }
 
 // SignedDataSize returns payload size of the request.

--- a/state/sign.go
+++ b/state/sign.go
@@ -1,0 +1,8 @@
+package state
+
+// SignedData returns payload bytes of the request.
+//
+// Always returns empty slice.
+func (m NetmapRequest) SignedData() ([]byte, error) {
+	return make([]byte, 0), nil
+}

--- a/state/sign.go
+++ b/state/sign.go
@@ -20,3 +20,10 @@ func (m MetricsRequest) SignedData() ([]byte, error) {
 func (m HealthRequest) SignedData() ([]byte, error) {
 	return make([]byte, 0), nil
 }
+
+// SignedData returns payload bytes of the request.
+//
+// Always returns an empty slice.
+func (m DumpRequest) SignedData() ([]byte, error) {
+	return make([]byte, 0), nil
+}

--- a/state/sign.go
+++ b/state/sign.go
@@ -1,5 +1,9 @@
 package state
 
+import (
+	"io"
+)
+
 // SignedData returns payload bytes of the request.
 //
 // Always returns an empty slice.
@@ -33,4 +37,35 @@ func (m DumpRequest) SignedData() ([]byte, error) {
 // Always returns an empty slice.
 func (m DumpVarsRequest) SignedData() ([]byte, error) {
 	return make([]byte, 0), nil
+}
+
+// SignedData returns payload bytes of the request.
+func (m ChangeStateRequest) SignedData() ([]byte, error) {
+	data := make([]byte, m.SignedDataSize())
+
+	if _, err := m.ReadSignedData(data); err != nil {
+		return nil, err
+	}
+
+	return data, nil
+}
+
+// SignedDataSize returns payload size of the request.
+func (m ChangeStateRequest) SignedDataSize() int {
+	return m.GetState().Size()
+}
+
+// ReadSignedData copies payload bytes to passed buffer.
+//
+// If the Request size is insufficient, io.ErrUnexpectedEOF returns.
+func (m ChangeStateRequest) ReadSignedData(p []byte) (int, error) {
+	if len(p) < m.SignedDataSize() {
+		return 0, io.ErrUnexpectedEOF
+	}
+
+	var off int
+
+	off += copy(p[off:], m.GetState().Bytes())
+
+	return off, nil
 }

--- a/state/sign.go
+++ b/state/sign.go
@@ -2,6 +2,8 @@ package state
 
 import (
 	"io"
+
+	"github.com/nspcc-dev/neofs-api-go/service"
 )
 
 // SignedData returns payload bytes of the request.
@@ -41,13 +43,7 @@ func (m DumpVarsRequest) SignedData() ([]byte, error) {
 
 // SignedData returns payload bytes of the request.
 func (m ChangeStateRequest) SignedData() ([]byte, error) {
-	data := make([]byte, m.SignedDataSize())
-
-	if _, err := m.ReadSignedData(data); err != nil {
-		return nil, err
-	}
-
-	return data, nil
+	return service.SignedDataFromReader(m)
 }
 
 // SignedDataSize returns payload size of the request.

--- a/state/sign.go
+++ b/state/sign.go
@@ -6,3 +6,10 @@ package state
 func (m NetmapRequest) SignedData() ([]byte, error) {
 	return make([]byte, 0), nil
 }
+
+// SignedData returns payload bytes of the request.
+//
+// Always returns empty slice.
+func (m MetricsRequest) SignedData() ([]byte, error) {
+	return make([]byte, 0), nil
+}

--- a/state/sign.go
+++ b/state/sign.go
@@ -27,3 +27,10 @@ func (m HealthRequest) SignedData() ([]byte, error) {
 func (m DumpRequest) SignedData() ([]byte, error) {
 	return make([]byte, 0), nil
 }
+
+// SignedData returns payload bytes of the request.
+//
+// Always returns an empty slice.
+func (m DumpVarsRequest) SignedData() ([]byte, error) {
+	return make([]byte, 0), nil
+}

--- a/state/sign.go
+++ b/state/sign.go
@@ -2,14 +2,21 @@ package state
 
 // SignedData returns payload bytes of the request.
 //
-// Always returns empty slice.
+// Always returns an empty slice.
 func (m NetmapRequest) SignedData() ([]byte, error) {
 	return make([]byte, 0), nil
 }
 
 // SignedData returns payload bytes of the request.
 //
-// Always returns empty slice.
+// Always returns an empty slice.
 func (m MetricsRequest) SignedData() ([]byte, error) {
+	return make([]byte, 0), nil
+}
+
+// SignedData returns payload bytes of the request.
+//
+// Always returns an empty slice.
+func (m HealthRequest) SignedData() ([]byte, error) {
 	return make([]byte, 0), nil
 }

--- a/state/sign_test.go
+++ b/state/sign_test.go
@@ -1,0 +1,62 @@
+package state
+
+import (
+	"testing"
+
+	"github.com/nspcc-dev/neofs-api-go/service"
+	"github.com/nspcc-dev/neofs-crypto/test"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRequestSign(t *testing.T) {
+	sk := test.DecodeKey(0)
+
+	type sigType interface {
+		service.SignedDataWithToken
+		service.SignKeyPairAccumulator
+		service.SignKeyPairSource
+		SetToken(*service.Token)
+	}
+
+	items := []struct {
+		constructor    func() sigType
+		payloadCorrupt []func(sigType)
+	}{
+		{ // NetmapRequest
+			constructor: func() sigType {
+				return new(NetmapRequest)
+			},
+		},
+	}
+
+	for _, item := range items {
+		{ // token corruptions
+			v := item.constructor()
+
+			token := new(service.Token)
+			v.SetToken(token)
+
+			require.NoError(t, service.SignDataWithSessionToken(sk, v))
+
+			require.NoError(t, service.VerifyAccumulatedSignaturesWithToken(v))
+
+			token.SetSessionKey(append(token.GetSessionKey(), 1))
+
+			require.Error(t, service.VerifyAccumulatedSignaturesWithToken(v))
+		}
+
+		{ // payload corruptions
+			for _, corruption := range item.payloadCorrupt {
+				v := item.constructor()
+
+				require.NoError(t, service.SignDataWithSessionToken(sk, v))
+
+				require.NoError(t, service.VerifyAccumulatedSignaturesWithToken(v))
+
+				corruption(v)
+
+				require.Error(t, service.VerifyAccumulatedSignaturesWithToken(v))
+			}
+		}
+	}
+}

--- a/state/sign_test.go
+++ b/state/sign_test.go
@@ -32,6 +32,11 @@ func TestRequestSign(t *testing.T) {
 				return new(MetricsRequest)
 			},
 		},
+		{ // HealthRequest
+			constructor: func() sigType {
+				return new(HealthRequest)
+			},
+		},
 	}
 
 	for _, item := range items {

--- a/state/sign_test.go
+++ b/state/sign_test.go
@@ -37,6 +37,11 @@ func TestRequestSign(t *testing.T) {
 				return new(HealthRequest)
 			},
 		},
+		{ // DumpRequest
+			constructor: func() sigType {
+				return new(DumpRequest)
+			},
+		},
 	}
 
 	for _, item := range items {

--- a/state/sign_test.go
+++ b/state/sign_test.go
@@ -47,6 +47,18 @@ func TestRequestSign(t *testing.T) {
 				return new(DumpVarsRequest)
 			},
 		},
+		{
+			constructor: func() sigType {
+				return new(ChangeStateRequest)
+			},
+			payloadCorrupt: []func(sigType){
+				func(s sigType) {
+					req := s.(*ChangeStateRequest)
+
+					req.SetState(req.GetState() + 1)
+				},
+			},
+		},
 	}
 
 	for _, item := range items {

--- a/state/sign_test.go
+++ b/state/sign_test.go
@@ -42,6 +42,11 @@ func TestRequestSign(t *testing.T) {
 				return new(DumpRequest)
 			},
 		},
+		{ // DumpVarsRequest
+			constructor: func() sigType {
+				return new(DumpVarsRequest)
+			},
+		},
 	}
 
 	for _, item := range items {

--- a/state/sign_test.go
+++ b/state/sign_test.go
@@ -27,6 +27,11 @@ func TestRequestSign(t *testing.T) {
 				return new(NetmapRequest)
 			},
 		},
+		{ // MetricsRequest
+			constructor: func() sigType {
+				return new(MetricsRequest)
+			},
+		},
 	}
 
 	for _, item := range items {

--- a/state/types.go
+++ b/state/types.go
@@ -1,0 +1,24 @@
+package state
+
+import (
+	"encoding/binary"
+)
+
+// SetState is a State field setter.
+func (m *ChangeStateRequest) SetState(st ChangeStateRequest_State) {
+	m.State = st
+}
+
+// Size returns the size of the state binary representation.
+func (ChangeStateRequest_State) Size() int {
+	return 4
+}
+
+// Bytes returns the state binary representation.
+func (x ChangeStateRequest_State) Bytes() []byte {
+	data := make([]byte, x.Size())
+
+	binary.BigEndian.PutUint32(data, uint32(x))
+
+	return data
+}

--- a/state/types_test.go
+++ b/state/types_test.go
@@ -1,0 +1,18 @@
+package state
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestChangeStateRequestGettersSetters(t *testing.T) {
+	t.Run("state", func(t *testing.T) {
+		st := ChangeStateRequest_State(1)
+		m := new(ChangeStateRequest)
+
+		m.SetState(st)
+
+		require.Equal(t, st, m.GetState())
+	})
+}


### PR DESCRIPTION
In order to support the signing through `service.AddSignatureWithKey`, `service.SignDataWithSessionToken` and verification through the related functions, all request messages must implement `service.SignedDataSource` interface methods.