### PR TITLE
Change AddSignKey of SessionToken

### DIFF
--- a/service/token.go
+++ b/service/token.go
@@ -6,6 +6,7 @@ import (
 	"io"
 
 	"github.com/nspcc-dev/neofs-api-go/refs"
+	crypto "github.com/nspcc-dev/neofs-crypto"
 )
 
 type signAccumWithToken struct {
@@ -125,10 +126,14 @@ func (x Token_Info_Verb) Bytes() []byte {
 	return data
 }
 
-// AddSignKey calls a Signature field setter of token with passed signature.
-func (s signedSessionToken) AddSignKey(sig []byte, _ *ecdsa.PublicKey) {
+// AddSignKey calls a Signature field setter and an OwnerKey field setter with corresponding arguments.
+func (s signedSessionToken) AddSignKey(sig []byte, key *ecdsa.PublicKey) {
 	if s.SessionToken != nil {
 		s.SessionToken.SetSignature(sig)
+
+		s.SessionToken.SetOwnerKey(
+			crypto.MarshalPublicKey(key),
+		)
 	}
 }
 

--- a/service/token.go
+++ b/service/token.go
@@ -174,11 +174,11 @@ func NewVerifiedSessionToken(token SessionToken) DataWithSignature {
 	}
 }
 
-func tokenInfoSize(v SessionTokenInfo) int {
+func tokenInfoSize(v SessionKeySource) int {
 	if v == nil {
 		return 0
 	}
-	return fixedTokenDataSize + len(v.GetSessionKey()) + len(v.GetOwnerKey())
+	return fixedTokenDataSize + len(v.GetSessionKey())
 }
 
 // Fills passed buffer with signing token information bytes.
@@ -208,9 +208,7 @@ func copyTokenSignedData(buf []byte, token SessionTokenInfo) {
 	tokenEndianness.PutUint64(buf[off:], token.ExpirationEpoch())
 	off += 8
 
-	off += copy(buf[off:], token.GetSessionKey())
-
-	copy(buf[off:], token.GetOwnerKey())
+	copy(buf[off:], token.GetSessionKey())
 }
 
 // SignedData concatenates signed data with session token information. Returns concatenation result.

--- a/service/token_test.go
+++ b/service/token_test.go
@@ -77,16 +77,6 @@ func TestTokenGettersSetters(t *testing.T) {
 		require.Equal(t, key, tok.GetSessionKey())
 	}
 
-	{
-		key := make([]byte, 10)
-		_, err := rand.Read(key)
-		require.NoError(t, err)
-
-		tok.SetOwnerKey(key)
-
-		require.Equal(t, key, tok.GetOwnerKey())
-	}
-
 	{ // Signature
 		sig := make([]byte, 10)
 		_, err := rand.Read(sig)
@@ -135,11 +125,6 @@ func TestSignToken(t *testing.T) {
 	_, err = rand.Read(sessionKey[:])
 	require.NoError(t, err)
 	token.SetSessionKey(sessionKey)
-
-	ownerKey := make([]byte, 10)
-	_, err = rand.Read(ownerKey[:])
-	require.NoError(t, err)
-	token.SetOwnerKey(ownerKey)
 
 	signedToken := NewSignedSessionToken(token)
 	verifiedToken := NewVerifiedSessionToken(token)
@@ -224,18 +209,6 @@ func TestSignToken(t *testing.T) {
 			restore: func() {
 				sessionKey[0]--
 				token.SetSessionKey(sessionKey)
-			},
-		},
-		{ // Owner key
-			corrupt: func() {
-				ownerKey := token.GetOwnerKey()
-				ownerKey[0]++
-				token.SetOwnerKey(ownerKey)
-			},
-			restore: func() {
-				ownerKey := token.GetOwnerKey()
-				ownerKey[0]--
-				token.SetOwnerKey(ownerKey)
 			},
 		},
 	}

--- a/service/token_test.go
+++ b/service/token_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/nspcc-dev/neofs-api-go/refs"
+	crypto "github.com/nspcc-dev/neofs-crypto"
 	"github.com/nspcc-dev/neofs-crypto/test"
 	"github.com/stretchr/testify/require"
 )
@@ -219,4 +220,29 @@ func TestSignToken(t *testing.T) {
 		v.restore()
 		require.NoError(t, VerifySignatureWithKey(pk, verifiedToken))
 	}
+}
+
+func TestSignedSessionToken_AddSignKey(t *testing.T) {
+	// nil SessionToken
+	s := new(signedSessionToken)
+
+	require.NotPanics(t, func() {
+		s.AddSignKey(nil, nil)
+	})
+
+	// create test public key and signature
+	pk := &test.DecodeKey(0).PublicKey
+	sig := []byte{1, 2, 3}
+
+	s.SessionToken = new(Token)
+
+	// add key-signature pair to SessionToken
+	s.AddSignKey(sig, pk)
+
+	require.Equal(t, sig, s.GetSignature())
+
+	require.Equal(t,
+		crypto.MarshalPublicKey(pk),
+		s.GetOwnerKey(),
+	)
 }


### PR DESCRIPTION
Summary:

- remove the owner key from the signed payload of `SessionToken`;

- call `OwnerKey` field setter in `AddSignKey` method of signed session token.