### PR TITLE
object: implement SignedData() and AddSignKey() methods on IntegrityH…

### DIFF
--- a/object/sign.go
+++ b/object/sign.go
@@ -1,6 +1,7 @@
 package object
 
 import (
+	"crypto/ecdsa"
 	"encoding/binary"
 	"io"
 
@@ -258,4 +259,14 @@ func addressSize(addr Address) int {
 
 func addressBytes(addr Address) []byte {
 	return append(addr.CID.Bytes(), addr.ObjectID.Bytes()...)
+}
+
+// SignedData returns the result of the ChecksumSignature field getter.
+func (m IntegrityHeader) SignedData() ([]byte, error) {
+	return m.GetHeadersChecksum(), nil
+}
+
+// AddSignKey calls the ChecksumSignature field setter with signature argument.
+func (m *IntegrityHeader) AddSignKey(sign []byte, _ *ecdsa.PublicKey) {
+	m.SetSignature(sign)
 }

--- a/object/sign_test.go
+++ b/object/sign_test.go
@@ -219,3 +219,21 @@ func testData(t *testing.T, sz int) []byte {
 
 	return data
 }
+
+func TestIntegrityHeaderSignMethods(t *testing.T) {
+	// create new IntegrityHeader
+	s := new(IntegrityHeader)
+
+	// set test headers checksum
+	s.SetHeadersChecksum([]byte{1, 2, 3})
+
+	data, err := s.SignedData()
+	require.NoError(t, err)
+	require.Equal(t, data, s.GetHeadersChecksum())
+
+	// add signature
+	sig := []byte{4, 5, 6}
+	s.AddSignKey(sig, nil)
+
+	require.Equal(t, sig, s.GetSignature())
+}

--- a/object/types.go
+++ b/object/types.go
@@ -391,3 +391,18 @@ func Stringify(dst io.Writer, obj *Object) error {
 func (m *HeadRequest) SetFullHeaders(v bool) {
 	m.FullHeaders = v
 }
+
+// GetSignature is a ChecksumSignature field getter.
+func (m IntegrityHeader) GetSignature() []byte {
+	return m.ChecksumSignature
+}
+
+// SetSignature is a ChecksumSignature field setter.
+func (m *IntegrityHeader) SetSignature(v []byte) {
+	m.ChecksumSignature = v
+}
+
+// SetHeadersChecksum is a HeadersChecksum field setter.
+func (m *IntegrityHeader) SetHeadersChecksum(v []byte) {
+	m.HeadersChecksum = v
+}

--- a/object/types_test.go
+++ b/object/types_test.go
@@ -199,3 +199,23 @@ func TestObject_Copy(t *testing.T) {
 		require.Equal(t, token, h.GetValue().(*Header_Token).Token)
 	})
 }
+
+func TestIntegrityHeaderGettersSetters(t *testing.T) {
+	t.Run("headers checksum", func(t *testing.T) {
+		data := []byte{1, 2, 3}
+
+		v := new(IntegrityHeader)
+
+		v.SetHeadersChecksum(data)
+		require.Equal(t, data, v.GetHeadersChecksum())
+	})
+
+	t.Run("headers checksum", func(t *testing.T) {
+		data := []byte{1, 2, 3}
+
+		v := new(IntegrityHeader)
+
+		v.SetSignature(data)
+		require.Equal(t, data, v.GetSignature())
+	})
+}


### PR DESCRIPTION
After these changes `object.IntegrityHeader` can be passed to `service.AddSignatureWithKey` / `service.VerifySignatureWithKey` methods in order to create / verify headers checksum signature.