### PR TITLE
service: support broken apart signable payload of the requests

### DIFF
--- a/accounting/sign_test.go
+++ b/accounting/sign_test.go
@@ -13,7 +13,7 @@ func TestSignBalanceRequest(t *testing.T) {
 	sk := test.DecodeKey(0)
 
 	type sigType interface {
-		service.SignedDataWithToken
+		service.RequestData
 		service.SignKeyPairAccumulator
 		service.SignKeyPairSource
 		SetToken(*service.Token)
@@ -159,26 +159,26 @@ func TestSignBalanceRequest(t *testing.T) {
 			token := new(service.Token)
 			v.SetToken(token)
 
-			require.NoError(t, service.SignDataWithSessionToken(sk, v))
+			require.NoError(t, service.SignRequestData(sk, v))
 
-			require.NoError(t, service.VerifyAccumulatedSignaturesWithToken(v))
+			require.NoError(t, service.VerifyRequestData(v))
 
 			token.SetSessionKey(append(token.GetSessionKey(), 1))
 
-			require.Error(t, service.VerifyAccumulatedSignaturesWithToken(v))
+			require.Error(t, service.VerifyRequestData(v))
 		}
 
 		{ // payload corruptions
 			for _, corruption := range item.payloadCorrupt {
 				v := item.constructor()
 
-				require.NoError(t, service.SignDataWithSessionToken(sk, v))
+				require.NoError(t, service.SignRequestData(sk, v))
 
-				require.NoError(t, service.VerifyAccumulatedSignaturesWithToken(v))
+				require.NoError(t, service.VerifyRequestData(v))
 
 				corruption(v)
 
-				require.Error(t, service.VerifyAccumulatedSignaturesWithToken(v))
+				require.Error(t, service.VerifyRequestData(v))
 			}
 		}
 	}

--- a/bootstrap/sign_test.go
+++ b/bootstrap/sign_test.go
@@ -12,7 +12,7 @@ func TestRequestSign(t *testing.T) {
 	sk := test.DecodeKey(0)
 
 	type sigType interface {
-		service.SignedDataWithToken
+		service.RequestData
 		service.SignKeyPairAccumulator
 		service.SignKeyPairSource
 		SetToken(*service.Token)
@@ -56,26 +56,26 @@ func TestRequestSign(t *testing.T) {
 			token := new(service.Token)
 			v.SetToken(token)
 
-			require.NoError(t, service.SignDataWithSessionToken(sk, v))
+			require.NoError(t, service.SignRequestData(sk, v))
 
-			require.NoError(t, service.VerifyAccumulatedSignaturesWithToken(v))
+			require.NoError(t, service.VerifyRequestData(v))
 
 			token.SetSessionKey(append(token.GetSessionKey(), 1))
 
-			require.Error(t, service.VerifyAccumulatedSignaturesWithToken(v))
+			require.Error(t, service.VerifyRequestData(v))
 		}
 
 		{ // payload corruptions
 			for _, corruption := range item.payloadCorrupt {
 				v := item.constructor()
 
-				require.NoError(t, service.SignDataWithSessionToken(sk, v))
+				require.NoError(t, service.SignRequestData(sk, v))
 
-				require.NoError(t, service.VerifyAccumulatedSignaturesWithToken(v))
+				require.NoError(t, service.VerifyRequestData(v))
 
 				corruption(v)
 
-				require.Error(t, service.VerifyAccumulatedSignaturesWithToken(v))
+				require.Error(t, service.VerifyRequestData(v))
 			}
 		}
 	}

--- a/container/sign_test.go
+++ b/container/sign_test.go
@@ -12,7 +12,7 @@ func TestRequestSign(t *testing.T) {
 	sk := test.DecodeKey(0)
 
 	type sigType interface {
-		service.SignedDataWithToken
+		service.RequestData
 		service.SignKeyPairAccumulator
 		service.SignKeyPairSource
 		SetToken(*service.Token)
@@ -117,26 +117,26 @@ func TestRequestSign(t *testing.T) {
 			token := new(service.Token)
 			v.SetToken(token)
 
-			require.NoError(t, service.SignDataWithSessionToken(sk, v))
+			require.NoError(t, service.SignRequestData(sk, v))
 
-			require.NoError(t, service.VerifyAccumulatedSignaturesWithToken(v))
+			require.NoError(t, service.VerifyRequestData(v))
 
 			token.SetSessionKey(append(token.GetSessionKey(), 1))
 
-			require.Error(t, service.VerifyAccumulatedSignaturesWithToken(v))
+			require.Error(t, service.VerifyRequestData(v))
 		}
 
 		{ // payload corruptions
 			for _, corruption := range item.payloadCorrupt {
 				v := item.constructor()
 
-				require.NoError(t, service.SignDataWithSessionToken(sk, v))
+				require.NoError(t, service.SignRequestData(sk, v))
 
-				require.NoError(t, service.VerifyAccumulatedSignaturesWithToken(v))
+				require.NoError(t, service.VerifyRequestData(v))
 
 				corruption(v)
 
-				require.Error(t, service.VerifyAccumulatedSignaturesWithToken(v))
+				require.Error(t, service.VerifyRequestData(v))
 			}
 		}
 	}

--- a/object/sign_test.go
+++ b/object/sign_test.go
@@ -13,7 +13,7 @@ func TestSignVerifyRequests(t *testing.T) {
 	sk := test.DecodeKey(0)
 
 	type sigType interface {
-		service.SignedDataWithToken
+		service.RequestData
 		service.SignKeyPairAccumulator
 		service.SignKeyPairSource
 		SetToken(*Token)
@@ -164,26 +164,26 @@ func TestSignVerifyRequests(t *testing.T) {
 			token := new(Token)
 			v.SetToken(token)
 
-			require.NoError(t, service.SignDataWithSessionToken(sk, v))
+			require.NoError(t, service.SignRequestData(sk, v))
 
-			require.NoError(t, service.VerifyAccumulatedSignaturesWithToken(v))
+			require.NoError(t, service.VerifyRequestData(v))
 
 			token.SetSessionKey(append(token.GetSessionKey(), 1))
 
-			require.Error(t, service.VerifyAccumulatedSignaturesWithToken(v))
+			require.Error(t, service.VerifyRequestData(v))
 		}
 
 		{ // payload corruptions
 			for _, corruption := range item.payloadCorrupt {
 				v := item.constructor()
 
-				require.NoError(t, service.SignDataWithSessionToken(sk, v))
+				require.NoError(t, service.SignRequestData(sk, v))
 
-				require.NoError(t, service.VerifyAccumulatedSignaturesWithToken(v))
+				require.NoError(t, service.VerifyRequestData(v))
 
 				corruption(v)
 
-				require.Error(t, service.VerifyAccumulatedSignaturesWithToken(v))
+				require.Error(t, service.VerifyRequestData(v))
 			}
 		}
 	}

--- a/service/errors.go
+++ b/service/errors.go
@@ -36,14 +36,18 @@ const ErrEmptyDataWithSignature = internal.Error("empty data with signature")
 // negative length for slice allocation.
 const ErrNegativeLength = internal.Error("negative slice length")
 
-// ErrNilDataWithTokenSignAccumulator is returned by functions that expect
-// a non-nil DataWithTokenSignAccumulator, but received nil.
-const ErrNilDataWithTokenSignAccumulator = internal.Error("signed data with token is nil")
+// ErrNilRequestSignedData is returned by functions that expect
+// a non-nil RequestSignedData, but received nil.
+const ErrNilRequestSignedData = internal.Error("request signed data is nil")
 
-// ErrNilSignatureKeySourceWithToken is returned by functions that expect
-// a non-nil SignatureKeySourceWithToken, but received nil.
-const ErrNilSignatureKeySourceWithToken = internal.Error("key-signature source with token is nil")
+// ErrNilRequestVerifyData is returned by functions that expect
+// a non-nil RequestVerifyData, but received nil.
+const ErrNilRequestVerifyData = internal.Error("request verification data is nil")
 
 // ErrNilSignedDataReader is returned by functions that expect
 // a non-nil SignedDataReader, but received nil.
 const ErrNilSignedDataReader = internal.Error("signed data reader is nil")
+
+// ErrNilSignKeyPairAccumulator is returned by functions that expect
+// a non-nil SignKeyPairAccumulator, but received nil.
+const ErrNilSignKeyPairAccumulator = internal.Error("signature-key pair accumulator is nil")

--- a/service/sign_test.go
+++ b/service/sign_test.go
@@ -257,16 +257,16 @@ func TestVerifySignatureWithKey(t *testing.T) {
 }
 
 func TestSignVerifyDataWithSessionToken(t *testing.T) {
-	// sign with empty DataWithTokenSignAccumulator
+	// sign with empty RequestSignedData
 	require.EqualError(t,
-		SignDataWithSessionToken(nil, nil),
-		ErrNilDataWithTokenSignAccumulator.Error(),
+		SignRequestData(nil, nil),
+		ErrNilRequestSignedData.Error(),
 	)
 
-	// verify with empty DataWithTokenSignSource
+	// verify with empty RequestVerifyData
 	require.EqualError(t,
-		VerifyAccumulatedSignaturesWithToken(nil),
-		ErrNilSignatureKeySourceWithToken.Error(),
+		VerifyRequestData(nil),
+		ErrNilRequestVerifyData.Error(),
 	)
 
 	// create test session token
@@ -287,16 +287,16 @@ func TestSignVerifyDataWithSessionToken(t *testing.T) {
 	sk := test.DecodeKey(0)
 
 	// sign with private key
-	require.NoError(t, SignDataWithSessionToken(sk, src))
+	require.NoError(t, SignRequestData(sk, src))
 
 	// ascertain that verification is passed
-	require.NoError(t, VerifyAccumulatedSignaturesWithToken(src))
+	require.NoError(t, VerifyRequestData(src))
 
 	// break the data
 	src.data[0]++
 
 	// ascertain that verification is failed
-	require.Error(t, VerifyAccumulatedSignaturesWithToken(src))
+	require.Error(t, VerifyRequestData(src))
 
 	// restore the data
 	src.data[0]--
@@ -305,13 +305,13 @@ func TestSignVerifyDataWithSessionToken(t *testing.T) {
 	token.SetVerb(initVerb + 1)
 
 	// ascertain that verification is failed
-	require.Error(t, VerifyAccumulatedSignaturesWithToken(src))
+	require.Error(t, VerifyRequestData(src))
 
 	// restore the token
 	token.SetVerb(initVerb)
 
 	// ascertain that verification is passed
-	require.NoError(t, VerifyAccumulatedSignaturesWithToken(src))
+	require.NoError(t, VerifyRequestData(src))
 
 	// wrap to data reader
 	rdr := &testSignedDataReader{
@@ -319,8 +319,8 @@ func TestSignVerifyDataWithSessionToken(t *testing.T) {
 	}
 
 	// sign with private key
-	require.NoError(t, SignDataWithSessionToken(sk, rdr))
+	require.NoError(t, SignRequestData(sk, rdr))
 
 	// ascertain that verification is passed
-	require.NoError(t, VerifyAccumulatedSignaturesWithToken(rdr))
+	require.NoError(t, VerifyRequestData(rdr))
 }

--- a/service/types.go
+++ b/service/types.go
@@ -250,20 +250,20 @@ type DataWithSignKeySource interface {
 	SignKeyPairSource
 }
 
-// SignedDataWithToken is an interface of data-token pair with read access.
-type SignedDataWithToken interface {
+// RequestData is an interface of the request information with read access.
+type RequestData interface {
 	SignedDataSource
 	SessionTokenSource
 }
 
-// DataWithTokenSignAccumulator is an interface of data-token pair with signature write access.
-type DataWithTokenSignAccumulator interface {
-	SignedDataWithToken
+// RequestSignedData is an interface of request information with signature write access.
+type RequestSignedData interface {
+	RequestData
 	SignKeyPairAccumulator
 }
 
-// DataWithTokenSignSource is an interface of data-token pair with signature read access.
-type DataWithTokenSignSource interface {
-	SignedDataWithToken
+// RequestVerifyData is an interface of request information with signature read access.
+type RequestVerifyData interface {
+	RequestData
 	SignKeyPairSource
 }

--- a/service/verify_test.go
+++ b/service/verify_test.go
@@ -69,7 +69,7 @@ func BenchmarkSignDataWithSessionToken(b *testing.B) {
 	b.ReportAllocs()
 
 	for i := 0; i < b.N; i++ {
-		require.NoError(b, SignDataWithSessionToken(key, req))
+		require.NoError(b, SignRequestData(key, req))
 	}
 }
 
@@ -91,14 +91,14 @@ func BenchmarkVerifyAccumulatedSignaturesWithToken(b *testing.B) {
 
 	for i := 0; i < 10; i++ {
 		key := test.DecodeKey(i)
-		require.NoError(b, SignDataWithSessionToken(key, req))
+		require.NoError(b, SignRequestData(key, req))
 	}
 
 	b.ResetTimer()
 	b.ReportAllocs()
 
 	for i := 0; i < b.N; i++ {
-		require.NoError(b, VerifyAccumulatedSignaturesWithToken(req))
+		require.NoError(b, VerifyRequestData(req))
 	}
 }
 

--- a/session/create.go
+++ b/session/create.go
@@ -53,7 +53,7 @@ func (s gRPCCreator) Create(ctx context.Context, p CreateParamsSource) (CreateRe
 	req.SetExpirationEpoch(p.ExpirationEpoch())
 
 	// sign with private key
-	if err := service.SignDataWithSessionToken(s.key, req); err != nil {
+	if err := service.SignRequestData(s.key, req); err != nil {
 		return nil, err
 	}
 

--- a/session/create_test.go
+++ b/session/create_test.go
@@ -84,7 +84,7 @@ func TestGRPCCreator_Create(t *testing.T) {
 			require.Equal(t, ownerID, req.GetOwnerID())
 			require.Equal(t, created, req.CreationEpoch())
 			require.Equal(t, expired, req.ExpirationEpoch())
-			require.NoError(t, service.VerifyAccumulatedSignaturesWithToken(req))
+			require.NoError(t, service.VerifyRequestData(req))
 		},
 		resp: &CreateResponse{
 			ID:         TokenID{1, 2, 3},

--- a/state/sign_test.go
+++ b/state/sign_test.go
@@ -12,7 +12,7 @@ func TestRequestSign(t *testing.T) {
 	sk := test.DecodeKey(0)
 
 	type sigType interface {
-		service.SignedDataWithToken
+		service.RequestData
 		service.SignKeyPairAccumulator
 		service.SignKeyPairSource
 		SetToken(*service.Token)
@@ -68,26 +68,26 @@ func TestRequestSign(t *testing.T) {
 			token := new(service.Token)
 			v.SetToken(token)
 
-			require.NoError(t, service.SignDataWithSessionToken(sk, v))
+			require.NoError(t, service.SignRequestData(sk, v))
 
-			require.NoError(t, service.VerifyAccumulatedSignaturesWithToken(v))
+			require.NoError(t, service.VerifyRequestData(v))
 
 			token.SetSessionKey(append(token.GetSessionKey(), 1))
 
-			require.Error(t, service.VerifyAccumulatedSignaturesWithToken(v))
+			require.Error(t, service.VerifyRequestData(v))
 		}
 
 		{ // payload corruptions
 			for _, corruption := range item.payloadCorrupt {
 				v := item.constructor()
 
-				require.NoError(t, service.SignDataWithSessionToken(sk, v))
+				require.NoError(t, service.SignRequestData(sk, v))
 
-				require.NoError(t, service.VerifyAccumulatedSignaturesWithToken(v))
+				require.NoError(t, service.VerifyRequestData(v))
 
 				corruption(v)
 
-				require.Error(t, service.VerifyAccumulatedSignaturesWithToken(v))
+				require.Error(t, service.VerifyRequestData(v))
 			}
 		}
 	}


### PR DESCRIPTION
In previous implementation service package provided types and functions
that wrapped signing/verification of data with session token.
This allowed us to use these functions for signing / verification of
service requests of other packages. To support the expansion of messages
with additional parts that need to be signed, you must be able to easily
expand the signed data with new parts.

To achieve the described goal, this commit makes the following changes:

  * adds GroupSignedPayloads and GroupVerifyPayloads functions;

  * renames SignedDataWithToken to RequestData, DataWithTokenSignAccumulator
    to RequestSignedData, DataWithTokenSignSource to RequestVerifyData;

  * renames SignDataWithSessionToken/VerifyAccumulatedSignaturesWithToken
    function to SignRequestData/VerifyRequestData and makes it to use
    GroupSignedPayloads/GroupVerifyPayloads internally.