### PR TITLE
service: implement BearerToken interface on BearerTokenMsg message

### DIFF
--- a/service/bearer.go
+++ b/service/bearer.go
@@ -119,6 +119,16 @@ func (m *BearerTokenMsg_Info) SetOwnerID(v OwnerID) {
 	m.OwnerID = v
 }
 
+// ExpirationEpoch returns the result of ValidUntil field getter.
+func (m BearerTokenMsg_Info) ExpirationEpoch() uint64 {
+	return m.GetValidUntil()
+}
+
+// SetExpirationEpoch passes argument to ValidUntil field setter.
+func (m *BearerTokenMsg_Info) SetExpirationEpoch(v uint64) {
+	m.SetValidUntil(v)
+}
+
 // SetOwnerKey is an OwnerKey field setter.
 func (m *BearerTokenMsg) SetOwnerKey(v []byte) {
 	m.OwnerKey = v
@@ -127,30 +137,4 @@ func (m *BearerTokenMsg) SetOwnerKey(v []byte) {
 // SetSignature is a Signature field setter.
 func (m *BearerTokenMsg) SetSignature(v []byte) {
 	m.Signature = v
-}
-
-func wrapBearerTokenMsg(msg *BearerTokenMsg) bearerMsgWrapper {
-	return bearerMsgWrapper{
-		BearerTokenMsg: msg,
-	}
-}
-
-// ExpirationEpoch returns the result of ValidUntil field getter.
-//
-// If message is nil, 0 returns.
-func (s bearerMsgWrapper) ExpirationEpoch() uint64 {
-	if s.BearerTokenMsg != nil {
-		return s.GetValidUntil()
-	}
-
-	return 0
-}
-
-// SetExpirationEpoch passes argument to ValidUntil field setter.
-//
-// If message is nil, nothing changes.
-func (s bearerMsgWrapper) SetExpirationEpoch(v uint64) {
-	if s.BearerTokenMsg != nil {
-		s.SetValidUntil(v)
-	}
 }

--- a/service/bearer_test.go
+++ b/service/bearer_test.go
@@ -182,6 +182,9 @@ func TestBearerTokenMsg_Setters(t *testing.T) {
 	s.SetValidUntil(validUntil)
 	require.Equal(t, validUntil, s.GetValidUntil())
 
+	s.SetExpirationEpoch(validUntil + 1)
+	require.Equal(t, validUntil+1, s.ExpirationEpoch())
+
 	ownerID := OwnerID{1, 2, 3}
 	s.SetOwnerID(ownerID)
 	require.Equal(t, ownerID, s.GetOwnerID())
@@ -193,19 +196,4 @@ func TestBearerTokenMsg_Setters(t *testing.T) {
 	sig := []byte{7, 8, 9}
 	s.SetSignature(sig)
 	require.Equal(t, sig, s.GetSignature())
-}
-
-func TestBearerMsgWrapper_ExpirationEpoch(t *testing.T) {
-	s := wrapBearerTokenMsg(nil)
-	require.Zero(t, s.ExpirationEpoch())
-	require.NotPanics(t, func() {
-		s.SetExpirationEpoch(1)
-	})
-
-	msg := new(BearerTokenMsg)
-	s = wrapBearerTokenMsg(msg)
-
-	epoch := uint64(7)
-	s.SetExpirationEpoch(epoch)
-	require.Equal(t, epoch, s.ExpirationEpoch())
 }

--- a/service/sign_test.go
+++ b/service/sign_test.go
@@ -286,7 +286,7 @@ func TestSignVerifyRequestData(t *testing.T) {
 		token    = new(Token)
 		initVerb = Token_Info_Verb(1)
 
-		bearer      = wrapBearerTokenMsg(new(BearerTokenMsg))
+		bearer      = new(BearerTokenMsg)
 		bearerEpoch = uint64(8)
 
 		extHdrKey = "key"

--- a/service/verify.go
+++ b/service/verify.go
@@ -109,7 +109,7 @@ func (t testCustomField) Marshal() ([]byte, error) { return nil, nil }
 // If Bearer field value is nil, nil returns.
 func (m RequestVerificationHeader) GetBearerToken() BearerToken {
 	if t := m.GetBearer(); t != nil {
-		return wrapBearerTokenMsg(t)
+		return t
 	}
 
 	return nil

--- a/service/verify_test.go
+++ b/service/verify_test.go
@@ -136,5 +136,5 @@ func TestRequestVerificationHeader_GetBearerToken(t *testing.T) {
 
 	bearer := new(BearerTokenMsg)
 	s.SetBearer(bearer)
-	require.Equal(t, wrapBearerTokenMsg(bearer), s.GetBearerToken())
+	require.Equal(t, bearer, s.GetBearerToken())
 }


### PR DESCRIPTION
This commit:

  * implements (Set)ExpirationEpoch methods on BearerTokenMsg;

  * removes BearerTokenMsg wrapper.