### PR TITLE
service: sign requests on the principle of Matryoshka

### DIFF
--- a/service/types.go
+++ b/service/types.go
@@ -262,6 +262,7 @@ type RequestData interface {
 type RequestSignedData interface {
 	RequestData
 	SignKeyPairAccumulator
+	SignKeyPairSource
 }
 
 // RequestVerifyData is an interface of request information with signature read access.


### PR DESCRIPTION
This commit changes SignRequestData / VerifyRequestData functions to
add the list of previous public keys to a signed message for all
requests.