### PR TITLE
Implement some universal structures

### DIFF
--- a/v2/accounting/accounting.go
+++ b/v2/accounting/accounting.go
@@ -17,6 +17,12 @@ type BalanceRequest struct {
 	verifyHeader *service.RequestVerificationHeader
 }
 
+type Decimal struct {
+	val int64
+
+	prec uint32
+}
+
 func (b *BalanceRequestBody) GetOwnerID() *refs.OwnerID {
 	if b != nil {
 		return b.ownerID
@@ -86,5 +92,33 @@ func (b *BalanceRequest) GetRequestVerificationHeader() *service.RequestVerifica
 func (b *BalanceRequest) SetRequestVerificationHeader(v *service.RequestVerificationHeader) {
 	if b != nil {
 		b.verifyHeader = v
+	}
+}
+
+func (d *Decimal) GetValue() int64 {
+	if d != nil {
+		return d.val
+	}
+
+	return 0
+}
+
+func (d *Decimal) SetValue(v int64) {
+	if d != nil {
+		d.val = v
+	}
+}
+
+func (d *Decimal) GetPrecision() uint32 {
+	if d != nil {
+		return d.prec
+	}
+
+	return 0
+}
+
+func (d *Decimal) SetPrecision(v uint32) {
+	if d != nil {
+		d.prec = v
 	}
 }

--- a/v2/accounting/accounting.go
+++ b/v2/accounting/accounting.go
@@ -79,7 +79,7 @@ func (b *BalanceRequest) SetBody(v *BalanceRequestBody) {
 	}
 }
 
-func (b *BalanceRequest) GetRequestMetaHeader() *service.RequestMetaHeader {
+func (b *BalanceRequest) GetMetaHeader() *service.RequestMetaHeader {
 	if b != nil {
 		return b.metaHeader
 	}
@@ -87,13 +87,13 @@ func (b *BalanceRequest) GetRequestMetaHeader() *service.RequestMetaHeader {
 	return nil
 }
 
-func (b *BalanceRequest) SetRequestMetaHeader(v *service.RequestMetaHeader) {
+func (b *BalanceRequest) SetMetaHeader(v *service.RequestMetaHeader) {
 	if b != nil {
 		b.metaHeader = v
 	}
 }
 
-func (b *BalanceRequest) GetRequestVerificationHeader() *service.RequestVerificationHeader {
+func (b *BalanceRequest) GetVerificationHeader() *service.RequestVerificationHeader {
 	if b != nil {
 		return b.verifyHeader
 	}
@@ -101,7 +101,7 @@ func (b *BalanceRequest) GetRequestVerificationHeader() *service.RequestVerifica
 	return nil
 }
 
-func (b *BalanceRequest) SetRequestVerificationHeader(v *service.RequestVerificationHeader) {
+func (b *BalanceRequest) SetVerificationHeader(v *service.RequestVerificationHeader) {
 	if b != nil {
 		b.verifyHeader = v
 	}
@@ -163,7 +163,7 @@ func (br *BalanceResponse) SetBody(v *BalanceResponseBody) {
 	}
 }
 
-func (br *BalanceResponse) GetResponseMetaHeader() *service.ResponseMetaHeader {
+func (br *BalanceResponse) GetMetaHeader() *service.ResponseMetaHeader {
 	if br != nil {
 		return br.metaHeader
 	}
@@ -171,13 +171,13 @@ func (br *BalanceResponse) GetResponseMetaHeader() *service.ResponseMetaHeader {
 	return nil
 }
 
-func (br *BalanceResponse) SetResponseMetaHeader(v *service.ResponseMetaHeader) {
+func (br *BalanceResponse) SetMetaHeader(v *service.ResponseMetaHeader) {
 	if br != nil {
 		br.metaHeader = v
 	}
 }
 
-func (br *BalanceResponse) GetResponseVerificationHeader() *service.ResponseVerificationHeader {
+func (br *BalanceResponse) GetVerificationHeader() *service.ResponseVerificationHeader {
 	if br != nil {
 		return br.verifyHeader
 	}
@@ -185,7 +185,7 @@ func (br *BalanceResponse) GetResponseVerificationHeader() *service.ResponseVeri
 	return nil
 }
 
-func (br *BalanceResponse) SetResponseVerificationHeader(v *service.ResponseVerificationHeader) {
+func (br *BalanceResponse) SetVerificationHeader(v *service.ResponseVerificationHeader) {
 	if br != nil {
 		br.verifyHeader = v
 	}

--- a/v2/accounting/accounting.go
+++ b/v2/accounting/accounting.go
@@ -17,6 +17,18 @@ type BalanceRequest struct {
 	verifyHeader *service.RequestVerificationHeader
 }
 
+type BalanceResponseBody struct {
+	bal *Decimal
+}
+
+type BalanceResponse struct {
+	body *BalanceResponseBody
+
+	metaHeader *service.ResponseMetaHeader
+
+	verifyHeader *service.ResponseVerificationHeader
+}
+
 type Decimal struct {
 	val int64
 
@@ -120,5 +132,61 @@ func (d *Decimal) GetPrecision() uint32 {
 func (d *Decimal) SetPrecision(v uint32) {
 	if d != nil {
 		d.prec = v
+	}
+}
+
+func (br *BalanceResponseBody) GetBalance() *Decimal {
+	if br != nil {
+		return br.bal
+	}
+
+	return nil
+}
+
+func (br *BalanceResponseBody) SetBalance(v *Decimal) {
+	if br != nil {
+		br.SetBalance(v)
+	}
+}
+
+func (br *BalanceResponse) GetBody() *BalanceResponseBody {
+	if br != nil {
+		return br.body
+	}
+
+	return nil
+}
+
+func (br *BalanceResponse) SetBody(v *BalanceResponseBody) {
+	if br != nil {
+		br.body = v
+	}
+}
+
+func (br *BalanceResponse) GetResponseMetaHeader() *service.ResponseMetaHeader {
+	if br != nil {
+		return br.metaHeader
+	}
+
+	return nil
+}
+
+func (br *BalanceResponse) SetResponseMetaHeader(v *service.ResponseMetaHeader) {
+	if br != nil {
+		br.metaHeader = v
+	}
+}
+
+func (br *BalanceResponse) GetResponseVerificationHeader() *service.ResponseVerificationHeader {
+	if br != nil {
+		return br.verifyHeader
+	}
+
+	return nil
+}
+
+func (br *BalanceResponse) SetResponseVerificationHeader(v *service.ResponseVerificationHeader) {
+	if br != nil {
+		br.verifyHeader = v
 	}
 }

--- a/v2/accounting/convert.go
+++ b/v2/accounting/convert.go
@@ -65,3 +65,29 @@ func BalanceRequestFromGRPCMessage(m *accounting.BalanceRequest) *BalanceRequest
 
 	return b
 }
+
+func DecimalToGRPCMessage(d *Decimal) *accounting.Decimal {
+	if d == nil {
+		return nil
+	}
+
+	m := new(accounting.Decimal)
+
+	m.SetValue(d.GetValue())
+	m.SetPrecision(d.GetPrecision())
+
+	return m
+}
+
+func DecimalFromGRPCMessage(m *accounting.Decimal) *Decimal {
+	if m == nil {
+		return nil
+	}
+
+	d := new(Decimal)
+
+	d.SetValue(m.GetValue())
+	d.SetPrecision(m.GetPrecision())
+
+	return d
+}

--- a/v2/accounting/convert.go
+++ b/v2/accounting/convert.go
@@ -4,7 +4,6 @@ import (
 	accounting "github.com/nspcc-dev/neofs-api-go/v2/accounting/grpc"
 	"github.com/nspcc-dev/neofs-api-go/v2/refs"
 	"github.com/nspcc-dev/neofs-api-go/v2/service"
-	grpcService "github.com/nspcc-dev/neofs-api-go/v2/service/grpc"
 )
 
 func BalanceRequestBodyToGRPCMessage(b *BalanceRequestBody) *accounting.BalanceRequest_Body {
@@ -35,44 +34,6 @@ func BalanceRequestBodyFromGRPCMessage(m *accounting.BalanceRequest_Body) *Balan
 	return b
 }
 
-func headersToGRPC(
-	src interface {
-		GetRequestMetaHeader() *service.RequestMetaHeader
-		GetRequestVerificationHeader() *service.RequestVerificationHeader
-	},
-	dst interface {
-		SetMetaHeader(*grpcService.RequestMetaHeader)
-		SetVerifyHeader(*grpcService.RequestVerificationHeader)
-	},
-) {
-	dst.SetMetaHeader(
-		service.RequestMetaHeaderToGRPCMessage(src.GetRequestMetaHeader()),
-	)
-
-	dst.SetVerifyHeader(
-		service.RequestVerificationHeaderToGRPCMessage(src.GetRequestVerificationHeader()),
-	)
-}
-
-func headersFromGRPC(
-	src interface {
-		GetMetaHeader() *grpcService.RequestMetaHeader
-		GetVerifyHeader() *grpcService.RequestVerificationHeader
-	},
-	dst interface {
-		SetRequestMetaHeader(*service.RequestMetaHeader)
-		SetRequestVerificationHeader(*service.RequestVerificationHeader)
-	},
-) {
-	dst.SetRequestMetaHeader(
-		service.RequestMetaHeaderFromGRPCMessage(src.GetMetaHeader()),
-	)
-
-	dst.SetRequestVerificationHeader(
-		service.RequestVerificationHeaderFromGRPCMessage(src.GetVerifyHeader()),
-	)
-}
-
 func BalanceRequestToGRPCMessage(b *BalanceRequest) *accounting.BalanceRequest {
 	if b == nil {
 		return nil
@@ -84,7 +45,7 @@ func BalanceRequestToGRPCMessage(b *BalanceRequest) *accounting.BalanceRequest {
 		BalanceRequestBodyToGRPCMessage(b.GetBody()),
 	)
 
-	headersToGRPC(b, m)
+	service.RequestHeadersToGRPC(b, m)
 
 	return m
 }
@@ -100,7 +61,7 @@ func BalanceRequestFromGRPCMessage(m *accounting.BalanceRequest) *BalanceRequest
 		BalanceRequestBodyFromGRPCMessage(m.GetBody()),
 	)
 
-	headersFromGRPC(m, b)
+	service.RequestHeadersFromGRPC(m, b)
 
 	return b
 }

--- a/v2/accounting/convert.go
+++ b/v2/accounting/convert.go
@@ -91,3 +91,63 @@ func DecimalFromGRPCMessage(m *accounting.Decimal) *Decimal {
 
 	return d
 }
+
+func BalanceResponseBodyToGRPCMessage(br *BalanceResponseBody) *accounting.BalanceResponse_Body {
+	if br == nil {
+		return nil
+	}
+
+	m := new(accounting.BalanceResponse_Body)
+
+	m.SetBalance(
+		DecimalToGRPCMessage(br.GetBalance()),
+	)
+
+	return m
+}
+
+func BalanceResponseBodyFromGRPCMessage(m *accounting.BalanceResponse_Body) *BalanceResponseBody {
+	if m == nil {
+		return nil
+	}
+
+	br := new(BalanceResponseBody)
+
+	br.SetBalance(
+		DecimalFromGRPCMessage(m.GetBalance()),
+	)
+
+	return br
+}
+
+func BalanceResponseToGRPCMessage(br *BalanceResponse) *accounting.BalanceResponse {
+	if br == nil {
+		return nil
+	}
+
+	m := new(accounting.BalanceResponse)
+
+	m.SetBody(
+		BalanceResponseBodyToGRPCMessage(br.GetBody()),
+	)
+
+	service.ResponseHeadersToGRPC(br, m)
+
+	return m
+}
+
+func BalanceResponseFromGRPCMessage(m *accounting.BalanceResponse) *BalanceResponse {
+	if m == nil {
+		return nil
+	}
+
+	br := new(BalanceResponse)
+
+	br.SetBody(
+		BalanceResponseBodyFromGRPCMessage(m.GetBody()),
+	)
+
+	service.ResponseHeadersFromGRPC(m, br)
+
+	return br
+}

--- a/v2/service/convert.go
+++ b/v2/service/convert.go
@@ -363,3 +363,149 @@ func RequestHeadersFromGRPC(
 		RequestVerificationHeaderFromGRPCMessage(src.GetVerifyHeader()),
 	)
 }
+
+func ResponseVerificationHeaderToGRPCMessage(r *ResponseVerificationHeader) *service.ResponseVerificationHeader {
+	if r == nil {
+		return nil
+	}
+
+	m := new(service.ResponseVerificationHeader)
+
+	m.SetBodySignature(
+		SignatureToGRPCMessage(r.GetBodySignature()),
+	)
+
+	m.SetMetaSignature(
+		SignatureToGRPCMessage(r.GetMetaSignature()),
+	)
+
+	m.SetOriginSignature(
+		SignatureToGRPCMessage(r.GetOriginSignature()),
+	)
+
+	m.SetOrigin(
+		ResponseVerificationHeaderToGRPCMessage(r.GetOrigin()),
+	)
+
+	return m
+}
+
+func ResponseVerificationHeaderFromGRPCMessage(m *service.ResponseVerificationHeader) *ResponseVerificationHeader {
+	if m == nil {
+		return nil
+	}
+
+	r := new(ResponseVerificationHeader)
+
+	r.SetBodySignature(
+		SignatureFromGRPCMessage(m.GetBodySignature()),
+	)
+
+	r.SetMetaSignature(
+		SignatureFromGRPCMessage(m.GetMetaSignature()),
+	)
+
+	r.SetOriginSignature(
+		SignatureFromGRPCMessage(m.GetOriginSignature()),
+	)
+
+	r.SetOrigin(
+		ResponseVerificationHeaderFromGRPCMessage(m.GetOrigin()),
+	)
+
+	return r
+}
+
+func ResponseMetaHeaderToGRPCMessage(r *ResponseMetaHeader) *service.ResponseMetaHeader {
+	if r == nil {
+		return nil
+	}
+
+	m := new(service.ResponseMetaHeader)
+
+	m.SetTtl(r.GetTTL())
+	m.SetEpoch(r.GetEpoch())
+
+	m.SetVersion(
+		VersionToGRPCMessage(r.GetVersion()),
+	)
+
+	m.SetOrigin(
+		ResponseMetaHeaderToGRPCMessage(r.GetOrigin()),
+	)
+
+	xHeaders := r.GetXHeaders()
+	xHdrMsg := make([]*service.XHeader, 0, len(xHeaders))
+
+	for i := range xHeaders {
+		xHdrMsg = append(xHdrMsg, XHeaderToGRPCMessage(xHeaders[i]))
+	}
+
+	return m
+}
+
+func ResponseMetaHeaderFromGRPCMessage(m *service.ResponseMetaHeader) *ResponseMetaHeader {
+	if m == nil {
+		return nil
+	}
+
+	r := new(ResponseMetaHeader)
+
+	r.SetTTL(m.GetTtl())
+	r.SetEpoch(m.GetEpoch())
+
+	r.SetVersion(
+		VersionFromGRPCMessage(m.GetVersion()),
+	)
+
+	r.SetOrigin(
+		ResponseMetaHeaderFromGRPCMessage(m.GetOrigin()),
+	)
+
+	xHdrMsg := m.GetXHeaders()
+	xHeaders := make([]*XHeader, 0, len(xHdrMsg))
+
+	for i := range xHdrMsg {
+		xHeaders = append(xHeaders, XHeaderFromGRPCMessage(xHdrMsg[i]))
+	}
+
+	return r
+}
+
+func ResponseHeadersToGRPC(
+	src interface {
+		GetResponseMetaHeader() *ResponseMetaHeader
+		GetResponseVerificationHeader() *ResponseVerificationHeader
+	},
+	dst interface {
+		SetMetaHeader(*service.ResponseMetaHeader)
+		SetVerifyHeader(*service.ResponseVerificationHeader)
+	},
+) {
+	dst.SetMetaHeader(
+		ResponseMetaHeaderToGRPCMessage(src.GetResponseMetaHeader()),
+	)
+
+	dst.SetVerifyHeader(
+		ResponseVerificationHeaderToGRPCMessage(src.GetResponseVerificationHeader()),
+	)
+}
+
+func ResponseHeadersFromGRPC(
+	src interface {
+		GetMetaHeader() *service.ResponseMetaHeader
+		GetVerifyHeader() *service.ResponseVerificationHeader
+	},
+	dst interface {
+		SetResponseMetaHeader(*ResponseMetaHeader)
+		SetResponseVerificationHeader(*ResponseVerificationHeader)
+	},
+) {
+	dst.SetResponseMetaHeader(
+		ResponseMetaHeaderFromGRPCMessage(src.GetMetaHeader()),
+	)
+
+	dst.SetResponseVerificationHeader(
+		ResponseVerificationHeaderFromGRPCMessage(src.GetVerifyHeader()),
+	)
+}

--- a/v2/service/convert.go
+++ b/v2/service/convert.go
@@ -328,8 +328,8 @@ func BearerTokenBodyFromGRPCMessage(m *service.BearerToken_Body) *BearerTokenBod
 
 func RequestHeadersToGRPC(
 	src interface {
-		GetRequestMetaHeader() *RequestMetaHeader
-		GetRequestVerificationHeader() *RequestVerificationHeader
+		GetMetaHeader() *RequestMetaHeader
+		GetVerificationHeader() *RequestVerificationHeader
 	},
 	dst interface {
 		SetMetaHeader(*service.RequestMetaHeader)
@@ -337,11 +337,11 @@ func RequestHeadersToGRPC(
 	},
 ) {
 	dst.SetMetaHeader(
-		RequestMetaHeaderToGRPCMessage(src.GetRequestMetaHeader()),
+		RequestMetaHeaderToGRPCMessage(src.GetMetaHeader()),
 	)
 
 	dst.SetVerifyHeader(
-		RequestVerificationHeaderToGRPCMessage(src.GetRequestVerificationHeader()),
+		RequestVerificationHeaderToGRPCMessage(src.GetVerificationHeader()),
 	)
 }
 
@@ -351,15 +351,15 @@ func RequestHeadersFromGRPC(
 		GetVerifyHeader() *service.RequestVerificationHeader
 	},
 	dst interface {
-		SetRequestMetaHeader(*RequestMetaHeader)
-		SetRequestVerificationHeader(*RequestVerificationHeader)
+		SetMetaHeader(*RequestMetaHeader)
+		SetVerificationHeader(*RequestVerificationHeader)
 	},
 ) {
-	dst.SetRequestMetaHeader(
+	dst.SetMetaHeader(
 		RequestMetaHeaderFromGRPCMessage(src.GetMetaHeader()),
 	)
 
-	dst.SetRequestVerificationHeader(
+	dst.SetVerificationHeader(
 		RequestVerificationHeaderFromGRPCMessage(src.GetVerifyHeader()),
 	)
 }
@@ -474,8 +474,8 @@ func ResponseMetaHeaderFromGRPCMessage(m *service.ResponseMetaHeader) *ResponseM
 
 func ResponseHeadersToGRPC(
 	src interface {
-		GetResponseMetaHeader() *ResponseMetaHeader
-		GetResponseVerificationHeader() *ResponseVerificationHeader
+		GetMetaHeader() *ResponseMetaHeader
+		GetVerificationHeader() *ResponseVerificationHeader
 	},
 	dst interface {
 		SetMetaHeader(*service.ResponseMetaHeader)
@@ -483,11 +483,11 @@ func ResponseHeadersToGRPC(
 	},
 ) {
 	dst.SetMetaHeader(
-		ResponseMetaHeaderToGRPCMessage(src.GetResponseMetaHeader()),
+		ResponseMetaHeaderToGRPCMessage(src.GetMetaHeader()),
 	)
 
 	dst.SetVerifyHeader(
-		ResponseVerificationHeaderToGRPCMessage(src.GetResponseVerificationHeader()),
+		ResponseVerificationHeaderToGRPCMessage(src.GetVerificationHeader()),
 	)
 }
 
@@ -497,15 +497,15 @@ func ResponseHeadersFromGRPC(
 		GetVerifyHeader() *service.ResponseVerificationHeader
 	},
 	dst interface {
-		SetResponseMetaHeader(*ResponseMetaHeader)
-		SetResponseVerificationHeader(*ResponseVerificationHeader)
+		SetMetaHeader(*ResponseMetaHeader)
+		SetVerificationHeader(*ResponseVerificationHeader)
 	},
 ) {
-	dst.SetResponseMetaHeader(
+	dst.SetMetaHeader(
 		ResponseMetaHeaderFromGRPCMessage(src.GetMetaHeader()),
 	)
 
-	dst.SetResponseVerificationHeader(
+	dst.SetVerificationHeader(
 		ResponseVerificationHeaderFromGRPCMessage(src.GetVerifyHeader()),
 	)
 }

--- a/v2/service/convert.go
+++ b/v2/service/convert.go
@@ -1,6 +1,8 @@
 package service
 
 import (
+	"github.com/nspcc-dev/neofs-api-go/v2/acl"
+	"github.com/nspcc-dev/neofs-api-go/v2/refs"
 	service "github.com/nspcc-dev/neofs-api-go/v2/service/grpc"
 )
 
@@ -67,13 +69,39 @@ func SessionTokenFromGRPCMessage(m *service.SessionToken) *SessionToken {
 }
 
 func BearerTokenToGRPCMessage(t *BearerToken) *service.BearerToken {
-	// TODO: fill me
-	return nil
+	if t == nil {
+		return nil
+	}
+
+	m := new(service.BearerToken)
+
+	m.SetBody(
+		BearerTokenBodyToGRPCMessage(t.GetBody()),
+	)
+
+	m.SetSignature(
+		SignatureToGRPCMessage(t.GetSignature()),
+	)
+
+	return m
 }
 
 func BearerTokenFromGRPCMessage(m *service.BearerToken) *BearerToken {
-	// TODO: fill me
-	return nil
+	if m == nil {
+		return nil
+	}
+
+	bt := new(BearerToken)
+
+	bt.SetBody(
+		BearerTokenBodyFromGRPCMessage(m.GetBody()),
+	)
+
+	bt.SetSignature(
+		SignatureFromGRPCMessage(m.GetSignature()),
+	)
+
+	return bt
 }
 
 func RequestVerificationHeaderToGRPCMessage(r *RequestVerificationHeader) *service.RequestVerificationHeader {
@@ -224,4 +252,76 @@ func SignatureFromGRPCMessage(m *service.Signature) *Signature {
 	s.SetSign(m.GetSign())
 
 	return s
+}
+
+func TokenLifetimeToGRPCMessage(tl *TokenLifetime) *service.TokenLifetime {
+	if tl == nil {
+		return nil
+	}
+
+	m := new(service.TokenLifetime)
+
+	m.SetExp(tl.GetExp())
+	m.SetNbf(tl.GetNbf())
+	m.SetIat(tl.GetIat())
+
+	return m
+}
+
+func TokenLifetimeFromGRPCMessage(m *service.TokenLifetime) *TokenLifetime {
+	if m == nil {
+		return nil
+	}
+
+	tl := new(TokenLifetime)
+
+	tl.SetExp(m.GetExp())
+	tl.SetNbf(m.GetNbf())
+	tl.SetIat(m.GetIat())
+
+	return tl
+}
+
+func BearerTokenBodyToGRPCMessage(v *BearerTokenBody) *service.BearerToken_Body {
+	if v == nil {
+		return nil
+	}
+
+	m := new(service.BearerToken_Body)
+
+	m.SetEaclTable(
+		acl.TableToGRPCMessage(v.GetEACL()),
+	)
+
+	m.SetOwnerId(
+		refs.OwnerIDToGRPCMessage(v.GetOwnerID()),
+	)
+
+	m.SetLifetime(
+		TokenLifetimeToGRPCMessage(v.GetLifetime()),
+	)
+
+	return m
+}
+
+func BearerTokenBodyFromGRPCMessage(m *service.BearerToken_Body) *BearerTokenBody {
+	if m == nil {
+		return nil
+	}
+
+	bt := new(BearerTokenBody)
+
+	bt.SetEACL(
+		acl.TableFromGRPCMessage(m.GetEaclTable()),
+	)
+
+	bt.SetOwnerID(
+		refs.OwnerIDFromGRPCMessage(m.GetOwnerId()),
+	)
+
+	bt.SetLifetime(
+		TokenLifetimeFromGRPCMessage(m.GetLifetime()),
+	)
+
+	return bt
 }

--- a/v2/service/convert.go
+++ b/v2/service/convert.go
@@ -199,3 +199,29 @@ func RequestMetaHeaderFromGRPCMessage(m *service.RequestMetaHeader) *RequestMeta
 
 	return r
 }
+
+func SignatureToGRPCMessage(s *Signature) *service.Signature {
+	if s == nil {
+		return nil
+	}
+
+	m := new(service.Signature)
+
+	m.SetKey(s.GetKey())
+	m.SetSign(s.GetSign())
+
+	return m
+}
+
+func SignatureFromGRPCMessage(m *service.Signature) *Signature {
+	if m == nil {
+		return nil
+	}
+
+	s := new(Signature)
+
+	s.SetKey(m.GetKey())
+	s.SetSign(m.GetSign())
+
+	return s
+}

--- a/v2/service/convert.go
+++ b/v2/service/convert.go
@@ -325,3 +325,41 @@ func BearerTokenBodyFromGRPCMessage(m *service.BearerToken_Body) *BearerTokenBod
 
 	return bt
 }
+
+func RequestHeadersToGRPC(
+	src interface {
+		GetRequestMetaHeader() *RequestMetaHeader
+		GetRequestVerificationHeader() *RequestVerificationHeader
+	},
+	dst interface {
+		SetMetaHeader(*service.RequestMetaHeader)
+		SetVerifyHeader(*service.RequestVerificationHeader)
+	},
+) {
+	dst.SetMetaHeader(
+		RequestMetaHeaderToGRPCMessage(src.GetRequestMetaHeader()),
+	)
+
+	dst.SetVerifyHeader(
+		RequestVerificationHeaderToGRPCMessage(src.GetRequestVerificationHeader()),
+	)
+}
+
+func RequestHeadersFromGRPC(
+	src interface {
+		GetMetaHeader() *service.RequestMetaHeader
+		GetVerifyHeader() *service.RequestVerificationHeader
+	},
+	dst interface {
+		SetRequestMetaHeader(*RequestMetaHeader)
+		SetRequestVerificationHeader(*RequestVerificationHeader)
+	},
+) {
+	dst.SetRequestMetaHeader(
+		RequestMetaHeaderFromGRPCMessage(src.GetMetaHeader()),
+	)
+
+	dst.SetRequestVerificationHeader(
+		RequestVerificationHeaderFromGRPCMessage(src.GetVerifyHeader()),
+	)
+}

--- a/v2/service/service.go
+++ b/v2/service/service.go
@@ -1,5 +1,10 @@
 package service
 
+import (
+	"github.com/nspcc-dev/neofs-api-go/v2/acl"
+	"github.com/nspcc-dev/neofs-api-go/v2/refs"
+)
+
 type Signature struct {
 	key, sign []byte
 }
@@ -12,12 +17,26 @@ type XHeader struct {
 	key, val string
 }
 
+type TokenLifetime struct {
+	exp, nbf, iat uint64
+}
+
 type SessionToken struct {
 	// TODO: fill me
 }
 
+type BearerTokenBody struct {
+	eacl *acl.Table
+
+	ownerID *refs.OwnerID
+
+	lifetime *TokenLifetime
+}
+
 type BearerToken struct {
-	// TODO: fill me
+	body *BearerTokenBody
+
+	sig *Signature
 }
 
 type RequestVerificationHeader struct {
@@ -310,4 +329,116 @@ func (r *RequestMetaHeader) StableMarshal(buf []byte) ([]byte, error) {
 func (r *RequestMetaHeader) StableSize() int {
 	// TODO: do not use hack
 	return RequestMetaHeaderToGRPCMessage(r).Size()
+}
+
+func (tl *TokenLifetime) GetExp() uint64 {
+	if tl != nil {
+		return tl.exp
+	}
+
+	return 0
+}
+
+func (tl *TokenLifetime) SetExp(v uint64) {
+	if tl != nil {
+		tl.exp = v
+	}
+}
+
+func (tl *TokenLifetime) GetNbf() uint64 {
+	if tl != nil {
+		return tl.nbf
+	}
+
+	return 0
+}
+
+func (tl *TokenLifetime) SetNbf(v uint64) {
+	if tl != nil {
+		tl.nbf = v
+	}
+}
+
+func (tl *TokenLifetime) GetIat() uint64 {
+	if tl != nil {
+		return tl.iat
+	}
+
+	return 0
+}
+
+func (tl *TokenLifetime) SetIat(v uint64) {
+	if tl != nil {
+		tl.iat = v
+	}
+}
+
+func (bt *BearerTokenBody) GetEACL() *acl.Table {
+	if bt != nil {
+		return bt.eacl
+	}
+
+	return nil
+}
+
+func (bt *BearerTokenBody) SetEACL(v *acl.Table) {
+	if bt != nil {
+		bt.eacl = v
+	}
+}
+
+func (bt *BearerTokenBody) GetOwnerID() *refs.OwnerID {
+	if bt != nil {
+		return bt.ownerID
+	}
+
+	return nil
+}
+
+func (bt *BearerTokenBody) SetOwnerID(v *refs.OwnerID) {
+	if bt != nil {
+		bt.ownerID = v
+	}
+}
+
+func (bt *BearerTokenBody) GetLifetime() *TokenLifetime {
+	if bt != nil {
+		return bt.lifetime
+	}
+
+	return nil
+}
+
+func (bt *BearerTokenBody) SetLifetime(v *TokenLifetime) {
+	if bt != nil {
+		bt.lifetime = v
+	}
+}
+
+func (bt *BearerToken) GetBody() *BearerTokenBody {
+	if bt != nil {
+		return bt.body
+	}
+
+	return nil
+}
+
+func (bt *BearerToken) SetBody(v *BearerTokenBody) {
+	if bt != nil {
+		bt.body = v
+	}
+}
+
+func (bt *BearerToken) GetSignature() *Signature {
+	if bt != nil {
+		return bt.sig
+	}
+
+	return nil
+}
+
+func (bt *BearerToken) SetSignature(v *Signature) {
+	if bt != nil {
+		bt.sig = v
+	}
 }

--- a/v2/service/service.go
+++ b/v2/service/service.go
@@ -61,6 +61,24 @@ type RequestMetaHeader struct {
 	origin *RequestMetaHeader
 }
 
+type ResponseVerificationHeader struct {
+	bodySig, metaSig, originSig *Signature
+
+	origin *ResponseVerificationHeader
+}
+
+type ResponseMetaHeader struct {
+	version *Version
+
+	ttl uint32
+
+	epoch uint64
+
+	xHeaders []*XHeader
+
+	origin *ResponseMetaHeader
+}
+
 func (s *Signature) GetKey() []byte {
 	if s != nil {
 		return s.key
@@ -440,5 +458,131 @@ func (bt *BearerToken) GetSignature() *Signature {
 func (bt *BearerToken) SetSignature(v *Signature) {
 	if bt != nil {
 		bt.sig = v
+	}
+}
+
+func (r *ResponseVerificationHeader) GetBodySignature() *Signature {
+	if r != nil {
+		return r.bodySig
+	}
+
+	return nil
+}
+
+func (r *ResponseVerificationHeader) SetBodySignature(v *Signature) {
+	if r != nil {
+		r.bodySig = v
+	}
+}
+
+func (r *ResponseVerificationHeader) GetMetaSignature() *Signature {
+	if r != nil {
+		return r.metaSig
+	}
+
+	return nil
+}
+
+func (r *ResponseVerificationHeader) SetMetaSignature(v *Signature) {
+	if r != nil {
+		r.metaSig = v
+	}
+}
+
+func (r *ResponseVerificationHeader) GetOriginSignature() *Signature {
+	if r != nil {
+		return r.originSig
+	}
+
+	return nil
+}
+
+func (r *ResponseVerificationHeader) SetOriginSignature(v *Signature) {
+	if r != nil {
+		r.originSig = v
+	}
+}
+
+func (r *ResponseVerificationHeader) GetOrigin() *ResponseVerificationHeader {
+	if r != nil {
+		return r.origin
+	}
+
+	return nil
+}
+
+func (r *ResponseVerificationHeader) SetOrigin(v *ResponseVerificationHeader) {
+	if r != nil {
+		r.origin = v
+	}
+}
+
+func (r *ResponseMetaHeader) GetVersion() *Version {
+	if r != nil {
+		return r.version
+	}
+
+	return nil
+}
+
+func (r *ResponseMetaHeader) SetVersion(v *Version) {
+	if r != nil {
+		r.version = v
+	}
+}
+
+func (r *ResponseMetaHeader) GetTTL() uint32 {
+	if r != nil {
+		return r.ttl
+	}
+
+	return 0
+}
+
+func (r *ResponseMetaHeader) SetTTL(v uint32) {
+	if r != nil {
+		r.ttl = v
+	}
+}
+
+func (r *ResponseMetaHeader) GetEpoch() uint64 {
+	if r != nil {
+		return r.epoch
+	}
+
+	return 0
+}
+
+func (r *ResponseMetaHeader) SetEpoch(v uint64) {
+	if r != nil {
+		r.epoch = v
+	}
+}
+
+func (r *ResponseMetaHeader) GetXHeaders() []*XHeader {
+	if r != nil {
+		return r.xHeaders
+	}
+
+	return nil
+}
+
+func (r *ResponseMetaHeader) SetXHeaders(v []*XHeader) {
+	if r != nil {
+		r.xHeaders = v
+	}
+}
+
+func (r *ResponseMetaHeader) GetOrigin() *ResponseMetaHeader {
+	if r != nil {
+		return r.origin
+	}
+
+	return nil
+}
+
+func (r *ResponseMetaHeader) SetOrigin(v *ResponseMetaHeader) {
+	if r != nil {
+		r.origin = v
 	}
 }

--- a/v2/service/service.go
+++ b/v2/service/service.go
@@ -1,9 +1,5 @@
 package service
 
-import (
-	service "github.com/nspcc-dev/neofs-api-go/v2/service/grpc"
-)
-
 type Signature struct {
 	key, sign []byte
 }
@@ -314,30 +310,4 @@ func (r *RequestMetaHeader) StableMarshal(buf []byte) ([]byte, error) {
 func (r *RequestMetaHeader) StableSize() int {
 	// TODO: do not use hack
 	return RequestMetaHeaderToGRPCMessage(r).Size()
-}
-
-func SignatureToGRPCMessage(s *Signature) *service.Signature {
-	if s == nil {
-		return nil
-	}
-
-	m := new(service.Signature)
-
-	m.SetKey(s.GetKey())
-	m.SetSign(s.GetSign())
-
-	return m
-}
-
-func SignatureFromGRPCMessage(m *service.Signature) *Signature {
-	if m == nil {
-		return nil
-	}
-
-	s := new(Signature)
-
-	s.SetKey(m.GetKey())
-	s.SetSign(m.GetSign())
-
-	return s
 }


### PR DESCRIPTION
Adds uni-structures with gRPC converters for:

- `service.BearerToken`;

- `service.ResponseMetaHeader`, `service.ResponseVerificationHeader`;

- `accounting.BalancerResponse`.