### PR TITLE
Rename unified client constructors

### DIFF
--- a/v2/accounting/client.go
+++ b/v2/accounting/client.go
@@ -62,7 +62,7 @@ func defaultCfg() *cfg {
 	}
 }
 
-func New(opts ...Option) (*Client, error) {
+func NewClient(opts ...Option) (*Client, error) {
 	cfg := defaultCfg()
 
 	for i := range opts {

--- a/v2/accounting/test/client_test.go
+++ b/v2/accounting/test/client_test.go
@@ -101,7 +101,7 @@ func TestGRPCClient(t *testing.T) {
 			server: srv,
 		}
 
-		c, err := accounting.New(accounting.WithGRPCServiceClient(cli))
+		c, err := accounting.NewClient(accounting.WithGRPCServiceClient(cli))
 		require.NoError(t, err)
 
 		resp, err := c.Balance(ctx, new(accounting.BalanceRequest))
@@ -114,7 +114,7 @@ func TestGRPCClient(t *testing.T) {
 
 		require.Error(t, signature.VerifyServiceMessage(req))
 
-		c, err := accounting.New(
+		c, err := accounting.NewClient(
 			accounting.WithGRPCServiceClient(
 				&testGRPCClient{
 					server: new(testGRPCServer),
@@ -141,7 +141,7 @@ func TestGRPCClient(t *testing.T) {
 			resp.SetMetaHeader(meta)
 		}
 
-		c, err := accounting.New(
+		c, err := accounting.NewClient(
 			accounting.WithGRPCServiceClient(
 				&testGRPCClient{
 					server: &testGRPCServer{

--- a/v2/container/client.go
+++ b/v2/container/client.go
@@ -172,7 +172,7 @@ func defaultCfg() *cfg {
 	}
 }
 
-func New(opts ...Option) (*Client, error) {
+func NewClient(opts ...Option) (*Client, error) {
 	cfg := defaultCfg()
 
 	for i := range opts {

--- a/v2/container/test/client_test.go
+++ b/v2/container/test/client_test.go
@@ -402,7 +402,7 @@ func TestGRPCClient_Put(t *testing.T) {
 			server: srv,
 		}
 
-		c, err := container.New(container.WithGRPCServiceClient(cli))
+		c, err := container.NewClient(container.WithGRPCServiceClient(cli))
 		require.NoError(t, err)
 
 		resp, err := c.Put(ctx, new(container.PutRequest))
@@ -415,7 +415,7 @@ func TestGRPCClient_Put(t *testing.T) {
 
 		require.Error(t, signature.VerifyServiceMessage(req))
 
-		c, err := container.New(
+		c, err := container.NewClient(
 			container.WithGRPCServiceClient(
 				&testGRPCClient{
 					server: new(testGRPCServer),
@@ -436,7 +436,7 @@ func TestGRPCClient_Put(t *testing.T) {
 
 		resp := testPutResponse()
 
-		c, err := container.New(
+		c, err := container.NewClient(
 			container.WithGRPCServiceClient(
 				&testGRPCClient{
 					server: &testGRPCServer{
@@ -474,7 +474,7 @@ func TestGRPCClient_Get(t *testing.T) {
 			server: srv,
 		}
 
-		c, err := container.New(container.WithGRPCServiceClient(cli))
+		c, err := container.NewClient(container.WithGRPCServiceClient(cli))
 		require.NoError(t, err)
 
 		resp, err := c.Get(ctx, new(container.GetRequest))
@@ -487,7 +487,7 @@ func TestGRPCClient_Get(t *testing.T) {
 
 		require.Error(t, signature.VerifyServiceMessage(req))
 
-		c, err := container.New(
+		c, err := container.NewClient(
 			container.WithGRPCServiceClient(
 				&testGRPCClient{
 					server: new(testGRPCServer),
@@ -508,7 +508,7 @@ func TestGRPCClient_Get(t *testing.T) {
 
 		resp := testGetResponse()
 
-		c, err := container.New(
+		c, err := container.NewClient(
 			container.WithGRPCServiceClient(
 				&testGRPCClient{
 					server: &testGRPCServer{
@@ -546,7 +546,7 @@ func TestGRPCClient_Delete(t *testing.T) {
 			server: srv,
 		}
 
-		c, err := container.New(container.WithGRPCServiceClient(cli))
+		c, err := container.NewClient(container.WithGRPCServiceClient(cli))
 		require.NoError(t, err)
 
 		resp, err := c.Delete(ctx, new(container.DeleteRequest))
@@ -559,7 +559,7 @@ func TestGRPCClient_Delete(t *testing.T) {
 
 		require.Error(t, signature.VerifyServiceMessage(req))
 
-		c, err := container.New(
+		c, err := container.NewClient(
 			container.WithGRPCServiceClient(
 				&testGRPCClient{
 					server: new(testGRPCServer),
@@ -580,7 +580,7 @@ func TestGRPCClient_Delete(t *testing.T) {
 
 		resp := testDelResponse()
 
-		c, err := container.New(
+		c, err := container.NewClient(
 			container.WithGRPCServiceClient(
 				&testGRPCClient{
 					server: &testGRPCServer{
@@ -618,7 +618,7 @@ func TestGRPCClient_List(t *testing.T) {
 			server: srv,
 		}
 
-		c, err := container.New(container.WithGRPCServiceClient(cli))
+		c, err := container.NewClient(container.WithGRPCServiceClient(cli))
 		require.NoError(t, err)
 
 		resp, err := c.List(ctx, new(container.ListRequest))
@@ -631,7 +631,7 @@ func TestGRPCClient_List(t *testing.T) {
 
 		require.Error(t, signature.VerifyServiceMessage(req))
 
-		c, err := container.New(
+		c, err := container.NewClient(
 			container.WithGRPCServiceClient(
 				&testGRPCClient{
 					server: new(testGRPCServer),
@@ -652,7 +652,7 @@ func TestGRPCClient_List(t *testing.T) {
 
 		resp := testListResponse()
 
-		c, err := container.New(
+		c, err := container.NewClient(
 			container.WithGRPCServiceClient(
 				&testGRPCClient{
 					server: &testGRPCServer{
@@ -690,7 +690,7 @@ func TestGRPCClient_SetEACL(t *testing.T) {
 			server: srv,
 		}
 
-		c, err := container.New(container.WithGRPCServiceClient(cli))
+		c, err := container.NewClient(container.WithGRPCServiceClient(cli))
 		require.NoError(t, err)
 
 		resp, err := c.SetExtendedACL(ctx, new(container.SetExtendedACLRequest))
@@ -702,7 +702,7 @@ func TestGRPCClient_SetEACL(t *testing.T) {
 
 		require.Error(t, signature.VerifyServiceMessage(req))
 
-		c, err := container.New(
+		c, err := container.NewClient(
 			container.WithGRPCServiceClient(
 				&testGRPCClient{
 					server: new(testGRPCServer),
@@ -723,7 +723,7 @@ func TestGRPCClient_SetEACL(t *testing.T) {
 
 		resp := testSetEACLResponse()
 
-		c, err := container.New(
+		c, err := container.NewClient(
 			container.WithGRPCServiceClient(
 				&testGRPCClient{
 					server: &testGRPCServer{
@@ -761,7 +761,7 @@ func TestGRPCClient_GetEACL(t *testing.T) {
 			server: srv,
 		}
 
-		c, err := container.New(container.WithGRPCServiceClient(cli))
+		c, err := container.NewClient(container.WithGRPCServiceClient(cli))
 		require.NoError(t, err)
 
 		resp, err := c.GetExtendedACL(ctx, new(container.GetExtendedACLRequest))
@@ -773,7 +773,7 @@ func TestGRPCClient_GetEACL(t *testing.T) {
 
 		require.Error(t, signature.VerifyServiceMessage(req))
 
-		c, err := container.New(
+		c, err := container.NewClient(
 			container.WithGRPCServiceClient(
 				&testGRPCClient{
 					server: new(testGRPCServer),
@@ -794,7 +794,7 @@ func TestGRPCClient_GetEACL(t *testing.T) {
 
 		resp := testGetEACLResponse()
 
-		c, err := container.New(
+		c, err := container.NewClient(
 			container.WithGRPCServiceClient(
 				&testGRPCClient{
 					server: &testGRPCServer{

--- a/v2/object/client.go
+++ b/v2/object/client.go
@@ -168,7 +168,7 @@ func defaultCfg() *cfg {
 	}
 }
 
-func New(opts ...Option) (*Client, error) {
+func NewClient(opts ...Option) (*Client, error) {
 	cfg := defaultCfg()
 
 	for i := range opts {

--- a/v2/object/test/client_test.go
+++ b/v2/object/test/client_test.go
@@ -274,7 +274,7 @@ func TestGRPCClient_Head(t *testing.T) {
 			server: srv,
 		}
 
-		c, err := object.New(object.WithGRPCServiceClient(cli))
+		c, err := object.NewClient(object.WithGRPCServiceClient(cli))
 		require.NoError(t, err)
 
 		resp, err := c.Head(ctx, new(object.HeadRequest))
@@ -287,7 +287,7 @@ func TestGRPCClient_Head(t *testing.T) {
 
 		require.Error(t, signature.VerifyServiceMessage(req))
 
-		c, err := object.New(
+		c, err := object.NewClient(
 			object.WithGRPCServiceClient(
 				&testGRPCClient{
 					server: new(testGRPCServer),
@@ -308,7 +308,7 @@ func TestGRPCClient_Head(t *testing.T) {
 
 		resp := testHeadResponse()
 
-		c, err := object.New(
+		c, err := object.NewClient(
 			object.WithGRPCServiceClient(
 				&testGRPCClient{
 					server: &testGRPCServer{
@@ -346,7 +346,7 @@ func TestGRPCClient_Delete(t *testing.T) {
 			server: srv,
 		}
 
-		c, err := object.New(object.WithGRPCServiceClient(cli))
+		c, err := object.NewClient(object.WithGRPCServiceClient(cli))
 		require.NoError(t, err)
 
 		resp, err := c.Delete(ctx, new(object.DeleteRequest))
@@ -359,7 +359,7 @@ func TestGRPCClient_Delete(t *testing.T) {
 
 		require.Error(t, signature.VerifyServiceMessage(req))
 
-		c, err := object.New(
+		c, err := object.NewClient(
 			object.WithGRPCServiceClient(
 				&testGRPCClient{
 					server: new(testGRPCServer),
@@ -380,7 +380,7 @@ func TestGRPCClient_Delete(t *testing.T) {
 
 		resp := testDeleteResponse()
 
-		c, err := object.New(
+		c, err := object.NewClient(
 			object.WithGRPCServiceClient(
 				&testGRPCClient{
 					server: &testGRPCServer{
@@ -418,7 +418,7 @@ func TestGRPCClient_GetRangeHash(t *testing.T) {
 			server: srv,
 		}
 
-		c, err := object.New(object.WithGRPCServiceClient(cli))
+		c, err := object.NewClient(object.WithGRPCServiceClient(cli))
 		require.NoError(t, err)
 
 		resp, err := c.GetRangeHash(ctx, new(object.GetRangeHashRequest))
@@ -431,7 +431,7 @@ func TestGRPCClient_GetRangeHash(t *testing.T) {
 
 		require.Error(t, signature.VerifyServiceMessage(req))
 
-		c, err := object.New(
+		c, err := object.NewClient(
 			object.WithGRPCServiceClient(
 				&testGRPCClient{
 					server: new(testGRPCServer),
@@ -452,7 +452,7 @@ func TestGRPCClient_GetRangeHash(t *testing.T) {
 
 		resp := testGetRangeHashResponse()
 
-		c, err := object.New(
+		c, err := object.NewClient(
 			object.WithGRPCServiceClient(
 				&testGRPCClient{
 					server: &testGRPCServer{

--- a/v2/session/client.go
+++ b/v2/session/client.go
@@ -62,7 +62,7 @@ func defaultCfg() *cfg {
 	}
 }
 
-func New(opts ...Option) (*Client, error) {
+func NewClient(opts ...Option) (*Client, error) {
 	cfg := defaultCfg()
 
 	for i := range opts {

--- a/v2/session/test/client_test.go
+++ b/v2/session/test/client_test.go
@@ -97,7 +97,7 @@ func TestGRPCClient(t *testing.T) {
 			server: srv,
 		}
 
-		c, err := session.New(session.WithGRPCServiceClient(cli))
+		c, err := session.NewClient(session.WithGRPCServiceClient(cli))
 		require.NoError(t, err)
 
 		resp, err := c.Create(ctx, new(session.CreateRequest))
@@ -110,7 +110,7 @@ func TestGRPCClient(t *testing.T) {
 
 		require.Error(t, signature.VerifyServiceMessage(req))
 
-		c, err := session.New(
+		c, err := session.NewClient(
 			session.WithGRPCServiceClient(
 				&testGRPCClient{
 					server: new(testGRPCServer),
@@ -137,7 +137,7 @@ func TestGRPCClient(t *testing.T) {
 			resp.SetMetaHeader(meta)
 		}
 
-		c, err := session.New(
+		c, err := session.NewClient(
 			session.WithGRPCServiceClient(
 				&testGRPCClient{
 					server: &testGRPCServer{


### PR DESCRIPTION
Client constructor `New` will be used as `package.New()` in external packages. This definition is not very clear since it can create new structure or new client or whatever. `package.NewClient()` is quite unambiguous.