### PR TITLE
Implement methods for use in local storage

### DIFF
--- a/pkg/object/address.go
+++ b/pkg/object/address.go
@@ -1,0 +1,68 @@
+package object
+
+import (
+	"github.com/nspcc-dev/neofs-api-go/pkg/container"
+	"github.com/nspcc-dev/neofs-api-go/v2/refs"
+	"github.com/pkg/errors"
+)
+
+// Address represents address of NeoFS object.
+type Address struct {
+	cid *container.ID
+
+	oid *ID
+}
+
+// ToV2 converts Address to v2 Address message.
+func (a *Address) ToV2() *refs.Address {
+	if a != nil {
+		aV2 := new(refs.Address)
+		aV2.SetContainerID(a.cid.ToV2())
+		aV2.SetObjectID(a.oid.ToV2())
+
+		return aV2
+	}
+
+	return nil
+}
+
+// GetObjectIDV2 converts object identifier to v2 ObjectID message.
+func (a *Address) GetObjectIDV2() *refs.ObjectID {
+	if a != nil {
+		return a.oid.ToV2()
+	}
+
+	return nil
+}
+
+// AddressFromV2 converts v2 Address message to Address.
+func AddressFromV2(aV2 *refs.Address) (*Address, error) {
+	if aV2 == nil {
+		return nil, nil
+	}
+
+	oid, err := IDFromV2(aV2.GetObjectID())
+	if err != nil {
+		return nil, errors.Wrap(err, "could not convert object identifier")
+	}
+
+	cid, err := container.IDFromV2(aV2.GetContainerID())
+	if err != nil {
+		return nil, errors.Wrap(err, "could not convert container identifier")
+	}
+
+	return &Address{
+		cid: cid,
+		oid: oid,
+	}, nil
+}
+
+// AddressFromBytes restores Address from a binary representation.
+func AddressFromBytes(data []byte) (*Address, error) {
+	addrV2 := new(refs.Address)
+	if err := addrV2.StableUnmarshal(data); err != nil {
+		return nil, errors.Wrap(err, "could not unmarshal object address")
+	}
+
+	return AddressFromV2(addrV2)
+}

--- a/pkg/object/object.go
+++ b/pkg/object/object.go
@@ -39,6 +39,8 @@ type rwObject struct {
 
 	payloadChecksum *refs.Checksum
 
+	payload []byte
+
 	// TODO: add other fields
 }
 
@@ -70,6 +72,14 @@ func (o *Object) Verify() error {
 		},
 	); err != nil {
 		return errors.Wrap(err, "invalid object ID signature")
+	}
+
+	return nil
+}
+
+func (o *Object) GetPayload() []byte {
+	if o != nil {
+		return o.payload
 	}
 
 	return nil
@@ -147,6 +157,7 @@ func (o *rwObject) ToV2(key *ecdsa.PrivateKey) (*object.Object, error) {
 	obj := new(object.Object)
 	obj.SetObjectID(o.id.ToV2())
 	obj.SetHeader(hdr)
+	obj.SetPayload(o.payload)
 
 	sig := new(refs.Signature)
 	sig.SetKey(o.key)
@@ -195,6 +206,7 @@ func FromV2(oV2 *object.Object) (*Object, error) {
 			cid:             cid,
 			ownerID:         ownerID,
 			payloadChecksum: hdr.GetPayloadHash(),
+			payload:         oV2.GetPayload(),
 		},
 	}, nil
 }

--- a/pkg/object/object.go
+++ b/pkg/object/object.go
@@ -77,9 +77,41 @@ func (o *Object) Verify() error {
 	return nil
 }
 
+// Address returns address of the object.
+func (o *Object) Address() *Address {
+	if o != nil {
+		return &Address{
+			cid: o.cid,
+			oid: o.id,
+		}
+	}
+
+	return nil
+}
+
+// GetPayload returns object payload bytes.
 func (o *Object) GetPayload() []byte {
 	if o != nil {
 		return o.payload
+	}
+
+	return nil
+}
+
+// CutPayload copies object fields w/o payload.
+func (o *Object) CutPayload() *Object {
+	if o != nil {
+		return &Object{
+			rwObject: rwObject{
+				fin:             o.fin,
+				id:              o.id,
+				key:             o.key,
+				sig:             o.sig,
+				cid:             o.cid,
+				ownerID:         o.ownerID,
+				payloadChecksum: o.payloadChecksum,
+			},
+		}
 	}
 
 	return nil
@@ -209,4 +241,14 @@ func FromV2(oV2 *object.Object) (*Object, error) {
 			payload:         oV2.GetPayload(),
 		},
 	}, nil
+}
+
+// FromBytes restores Object from a binary representation.
+func FromBytes(data []byte) (*Object, error) {
+	oV2 := new(object.Object)
+	if err := oV2.StableUnmarshal(data); err != nil {
+		return nil, errors.Wrap(err, "could not unmarshal object")
+	}
+
+	return FromV2(oV2)
 }

--- a/v2/object/marshal.go
+++ b/v2/object/marshal.go
@@ -2,6 +2,7 @@ package object
 
 import (
 	"github.com/nspcc-dev/neofs-api-go/util/proto"
+	object "github.com/nspcc-dev/neofs-api-go/v2/object/grpc"
 )
 
 const (
@@ -438,6 +439,21 @@ func (o *Object) StableSize() (size int) {
 	size += proto.BytesSize(objPayloadField, o.payload)
 
 	return size
+}
+
+func (o *Object) StableUnmarshal(data []byte) error {
+	if o == nil {
+		return nil
+	}
+
+	objGRPC := new(object.Object)
+	if err := objGRPC.Unmarshal(data); err != nil {
+		return err
+	}
+
+	*o = *ObjectFromGRPCMessage(objGRPC)
+
+	return nil
 }
 
 func (r *GetRequestBody) StableMarshal(buf []byte) ([]byte, error) {

--- a/v2/object/marshal_test.go
+++ b/v2/object/marshal_test.go
@@ -688,3 +688,15 @@ func generateRangeHashResponseBody(n int) *object.GetRangeHashResponseBody {
 
 	return resp
 }
+
+func TestObject_StableUnmarshal(t *testing.T) {
+	obj := generateObject("some data")
+
+	data, err := obj.StableMarshal(nil)
+	require.NoError(t, err)
+
+	obj2 := new(object.Object)
+	require.NoError(t, obj2.StableUnmarshal(data))
+
+	require.Equal(t, obj, obj2)
+}

--- a/v2/refs/marshal.go
+++ b/v2/refs/marshal.go
@@ -2,6 +2,7 @@ package refs
 
 import (
 	"github.com/nspcc-dev/neofs-api-go/util/proto"
+	refs "github.com/nspcc-dev/neofs-api-go/v2/refs/grpc"
 )
 
 const (
@@ -138,6 +139,21 @@ func (a *Address) StableSize() (size int) {
 	size += proto.NestedStructureSize(addressObjectField, a.oid)
 
 	return size
+}
+
+func (a *Address) StableUnmarshal(data []byte) error {
+	if a == nil {
+		return nil
+	}
+
+	addrGRPC := new(refs.Address)
+	if err := addrGRPC.Unmarshal(data); err != nil {
+		return err
+	}
+
+	*a = *AddressFromGRPCMessage(addrGRPC)
+
+	return nil
 }
 
 func (c *Checksum) StableMarshal(buf []byte) ([]byte, error) {

--- a/v2/refs/marshal_test.go
+++ b/v2/refs/marshal_test.go
@@ -63,20 +63,14 @@ func TestObjectID_StableMarshal(t *testing.T) {
 }
 
 func TestAddress_StableMarshal(t *testing.T) {
-	addressFrom := new(refs.Address)
+	cid := []byte("Container ID")
+	oid := []byte("Object ID")
 
-	cnr := new(refs.ContainerID)
-	cnr.SetValue([]byte("Container ID"))
-
-	objectID := new(refs.ObjectID)
-	objectID.SetValue([]byte("Object ID"))
+	addressFrom := generateAddress(cid, oid)
 
 	addressTransport := new(grpc.Address)
 
 	t.Run("non empty", func(t *testing.T) {
-		addressFrom.SetContainerID(cnr)
-		addressFrom.SetObjectID(objectID)
-
 		wire, err := addressFrom.StableMarshal(nil)
 		require.NoError(t, err)
 
@@ -153,4 +147,28 @@ func generateVersion(maj, min uint32) *refs.Version {
 	version.SetMinor(min)
 
 	return version
+}
+
+func generateAddress(bCid, bOid []byte) *refs.Address {
+	addr := new(refs.Address)
+
+	cid := new(refs.ContainerID)
+	cid.SetValue(bCid)
+
+	oid := new(refs.ObjectID)
+	oid.SetValue(bOid)
+
+	return addr
+}
+
+func TestAddress_StableUnmarshal(t *testing.T) {
+	addr := generateAddress([]byte("container id"), []byte("object id"))
+
+	data, err := addr.StableMarshal(nil)
+	require.NoError(t, err)
+
+	addr2 := new(refs.Address)
+	require.NoError(t, addr2.StableUnmarshal(data))
+
+	require.Equal(t, addr, addr2)
 }


### PR DESCRIPTION
## Summary

- Implement stable unmarshalers on v2 `refs.Address` and `object.Object`;

- Add  `Address` type to object SDK;

- Implement some useful methods and functions in object SDK.