### PR TITLE
Ignore EOF on buffer copy in object.Put

### DIFF
--- a/pkg/client/object.go
+++ b/pkg/client/object.go
@@ -264,7 +264,8 @@ func (c *Client) putObjectV2(ctx context.Context, p *PutObjectParams, opts ...Ca
 	}
 
 	// copy payload from reader to stream writer
-	if _, err := io.CopyBuffer(w, rPayload, make([]byte, chunkSize)); err != nil {
+	_, err = io.CopyBuffer(w, rPayload, make([]byte, chunkSize))
+	if err != nil && !errors.Is(errors.Cause(err), io.EOF) {
 		return nil, errors.Wrap(err, "could not send payload bytes to Put object stream")
 	}
 


### PR DESCRIPTION
There is a issue when user sends payload chunk to the neofs node, but node closes connection earlier, e.g. node can return error as soon as it checked ACL permission and denied request.

In this case client will receive EOF error and it produces `could not send payload bytes to Put object stream` error, but in fact there is different error.

If we ignore EOF there then `stream.CloseAndRecv()` return correct error message later.