### PR TITLE
Do not resign session token

### DIFF
--- a/pkg/client/object.go
+++ b/pkg/client/object.go
@@ -1006,7 +1006,14 @@ func (c Client) attachV2SessionToken(opts callOptions, hdr *v2session.RequestMet
 		return nil
 	}
 
-	token := opts.session.ToV2()
+	// Do not resign already prepared session token
+	if opts.session.Signature() != nil {
+		hdr.SetSessionToken(opts.session.ToV2())
+		return nil
+	}
+
+	token := new(v2session.SessionToken)
+	token.SetBody(opts.session.ToV2().GetBody())
 
 	opCtx := new(v2session.ObjectSessionContext)
 	opCtx.SetAddress(info.addr)

--- a/pkg/token/session.go
+++ b/pkg/token/session.go
@@ -1,6 +1,7 @@
 package token
 
 import (
+	"github.com/nspcc-dev/neofs-api-go/pkg"
 	"github.com/nspcc-dev/neofs-api-go/pkg/owner"
 	"github.com/nspcc-dev/neofs-api-go/v2/session"
 )
@@ -67,4 +68,11 @@ func (t *SessionToken) SetSessionKey(v []byte) {
 	t.setBodyField(func(body *session.SessionTokenBody) {
 		body.SetSessionKey(v)
 	})
+}
+
+func (t *SessionToken) Signature() *pkg.Signature {
+	return pkg.NewSignatureFromV2(
+		(*session.SessionToken)(t).
+			GetSignature(),
+	)
 }


### PR DESCRIPTION
In some cases SDK Client provided with signed and prepared session token. In this case we don't need to change verb or sign it.