### PR TITLE
v2: Print default values in JSON

### DIFF
--- a/v2/acl/json.go
+++ b/v2/acl/json.go
@@ -12,7 +12,7 @@ func RecordToJSON(r *Record) (data []byte) {
 
 	msg := RecordToGRPCMessage(r)
 
-	data, err := protojson.Marshal(msg)
+	data, err := protojson.MarshalOptions{EmitUnpopulated: true}.Marshal(msg)
 	if err != nil {
 		return nil
 	}
@@ -41,7 +41,7 @@ func TableToJSON(t *Table) (data []byte) {
 
 	msg := TableToGRPCMessage(t)
 
-	data, err := protojson.Marshal(msg)
+	data, err := protojson.MarshalOptions{EmitUnpopulated: true}.Marshal(msg)
 	if err != nil {
 		return nil
 	}
@@ -70,7 +70,7 @@ func BearerTokenToJSON(t *BearerToken) (data []byte) {
 
 	msg := BearerTokenToGRPCMessage(t)
 
-	data, err := protojson.Marshal(msg)
+	data, err := protojson.MarshalOptions{EmitUnpopulated: true}.Marshal(msg)
 	if err != nil {
 		return nil
 	}

--- a/v2/container/json.go
+++ b/v2/container/json.go
@@ -12,7 +12,7 @@ func ContainerToJSON(c *Container) (data []byte) {
 
 	msg := ContainerToGRPCMessage(c)
 
-	data, err := protojson.Marshal(msg)
+	data, err := protojson.MarshalOptions{EmitUnpopulated: true}.Marshal(msg)
 	if err != nil {
 		return nil
 	}

--- a/v2/netmap/json.go
+++ b/v2/netmap/json.go
@@ -12,7 +12,7 @@ func NodeInfoToJSON(n *NodeInfo) (data []byte) {
 
 	msg := NodeInfoToGRPCMessage(n)
 
-	data, err := protojson.Marshal(msg)
+	data, err := protojson.MarshalOptions{EmitUnpopulated: true}.Marshal(msg)
 	if err != nil {
 		return nil
 	}


### PR DESCRIPTION
This way zero-values will not be omitted in resulting string.

```json
  "version": {
    "major": 2,
    "minor": 0
  },
```