### PR TITLE
sdk/client: Ease bearer token sanity check

### DIFF
--- a/pkg/token/bearer.go
+++ b/pkg/token/bearer.go
@@ -95,12 +95,8 @@ func sanityCheck(b *BearerToken) error {
 		return errors.New("bearer token is not set")
 	case b.token.GetBody() == nil:
 		return errors.New("bearer token body is not set")
-	case b.token.GetBody().GetLifetime() == nil:
-		return errors.New("bearer token lifetime is not set")
 	case b.token.GetBody().GetEACL() == nil:
 		return errors.New("bearer token EACL table is not set")
-	case b.token.GetBody().GetOwnerID() == nil:
-		return errors.New("bearer token owner is not set")
 	}
 
 	// consider checking EACL sanity there, lifetime correctness, etc.

--- a/pkg/token/bearer_test.go
+++ b/pkg/token/bearer_test.go
@@ -1,0 +1,32 @@
+package token_test
+
+import (
+	"testing"
+
+	"github.com/nspcc-dev/neofs-api-go/pkg/acl/eacl"
+	"github.com/nspcc-dev/neofs-api-go/pkg/owner"
+	"github.com/nspcc-dev/neofs-api-go/pkg/token"
+	"github.com/nspcc-dev/neofs-crypto/test"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBearerToken_Issuer(t *testing.T) {
+	bearerToken := token.NewBearerToken()
+
+	t.Run("non signed token", func(t *testing.T) {
+		require.Nil(t, bearerToken.Issuer())
+	})
+
+	t.Run("signed token", func(t *testing.T) {
+		key := test.DecodeKey(1)
+
+		wallet, err := owner.NEO3WalletFromPublicKey(&key.PublicKey)
+		require.NoError(t, err)
+
+		ownerID := owner.NewIDFromNeo3Wallet(wallet)
+
+		bearerToken.SetEACLTable(eacl.NewTable())
+		require.NoError(t, bearerToken.SignToken(key))
+		require.Equal(t, bearerToken.Issuer().String(), ownerID.String())
+	})
+}


### PR DESCRIPTION
Now `OwnerID` field is not required to be set. According to latest neofs-api specification, this field set if token was issued for specific owner. If this field is not set, then any user can use this token while it is correctly signed and has valid lifetime.

Lifetime is also can be omitted since node interpret empty lifetime as a lifetime with zero values.