### PR TITLE
Return errors in JSON converters

### DIFF
--- a/v2/acl/json.go
+++ b/v2/acl/json.go
@@ -1,93 +1,84 @@
 package acl
 
 import (
+	"errors"
+
 	acl "github.com/nspcc-dev/neofs-api-go/v2/acl/grpc"
 	"google.golang.org/protobuf/encoding/protojson"
 )
 
-func RecordToJSON(r *Record) (data []byte) {
+var (
+	errEmptyInput = errors.New("empty input")
+)
+
+func RecordToJSON(r *Record) ([]byte, error) {
 	if r == nil {
-		return nil
+		return nil, errEmptyInput
 	}
 
 	msg := RecordToGRPCMessage(r)
 
-	data, err := protojson.MarshalOptions{EmitUnpopulated: true}.Marshal(msg)
-	if err != nil {
-		return nil
-	}
-
-	return
+	return protojson.MarshalOptions{EmitUnpopulated: true}.Marshal(msg)
 }
 
-func RecordFromJSON(data []byte) *Record {
+func RecordFromJSON(data []byte) (*Record, error) {
 	if len(data) == 0 {
-		return nil
+		return nil, errEmptyInput
 	}
 
 	msg := new(acl.EACLRecord)
 
 	if err := protojson.Unmarshal(data, msg); err != nil {
-		return nil
+		return nil, err
 	}
 
-	return RecordFromGRPCMessage(msg)
+	return RecordFromGRPCMessage(msg), nil
 }
 
-func TableToJSON(t *Table) (data []byte) {
+func TableToJSON(t *Table) ([]byte, error) {
 	if t == nil {
-		return nil
+		return nil, errEmptyInput
 	}
 
 	msg := TableToGRPCMessage(t)
 
-	data, err := protojson.MarshalOptions{EmitUnpopulated: true}.Marshal(msg)
-	if err != nil {
-		return nil
-	}
-
-	return
+	return protojson.MarshalOptions{EmitUnpopulated: true}.Marshal(msg)
 }
 
-func TableFromJSON(data []byte) *Table {
+func TableFromJSON(data []byte) (*Table, error) {
 	if len(data) == 0 {
-		return nil
+		return nil, errEmptyInput
 	}
 
 	msg := new(acl.EACLTable)
 
 	if err := protojson.Unmarshal(data, msg); err != nil {
-		return nil
+		return nil, err
 	}
 
-	return TableFromGRPCMessage(msg)
+	return TableFromGRPCMessage(msg), nil
 }
 
-func BearerTokenToJSON(t *BearerToken) (data []byte) {
+func BearerTokenToJSON(t *BearerToken) ([]byte, error) {
 	if t == nil {
-		return nil
+		return nil, errEmptyInput
 	}
 
 	msg := BearerTokenToGRPCMessage(t)
 
-	data, err := protojson.MarshalOptions{EmitUnpopulated: true}.Marshal(msg)
-	if err != nil {
-		return nil
-	}
-
-	return
+	return protojson.MarshalOptions{EmitUnpopulated: true}.Marshal(msg)
 }
 
-func BearerTokenFromJSON(data []byte) *BearerToken {
+func BearerTokenFromJSON(data []byte) (*BearerToken, error) {
 	if len(data) == 0 {
-		return nil
+		return nil, errEmptyInput
 	}
 
 	msg := new(acl.BearerToken)
 
 	if err := protojson.Unmarshal(data, msg); err != nil {
-		return nil
+		return nil, err
 	}
 
-	return BearerTokenFromGRPCMessage(msg)
+	return BearerTokenFromGRPCMessage(msg), nil
 }

--- a/v2/acl/json_test.go
+++ b/v2/acl/json_test.go
@@ -11,13 +11,21 @@ func TestRecordJSON(t *testing.T) {
 	exp := generateRecord(false)
 
 	t.Run("non empty", func(t *testing.T) {
-		data := acl.RecordToJSON(exp)
-		require.NotNil(t, data)
+		data, err := acl.RecordToJSON(exp)
+		require.NoError(t, err)
 
-		got := acl.RecordFromJSON(data)
-		require.NotNil(t, got)
+		got, err := acl.RecordFromJSON(data)
+		require.NoError(t, err)
 
 		require.Equal(t, exp, got)
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		_, err := acl.RecordToJSON(nil)
+		require.Error(t, err)
+
+		_, err = acl.RecordFromJSON(nil)
+		require.Error(t, err)
 	})
 }
 
@@ -25,13 +33,21 @@ func TestEACLTableJSON(t *testing.T) {
 	exp := generateEACL()
 
 	t.Run("non empty", func(t *testing.T) {
-		data := acl.TableToJSON(exp)
-		require.NotNil(t, data)
+		data, err := acl.TableToJSON(exp)
+		require.NoError(t, err)
 
-		got := acl.TableFromJSON(data)
-		require.NotNil(t, got)
+		got, err := acl.TableFromJSON(data)
+		require.NoError(t, err)
 
 		require.Equal(t, exp, got)
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		_, err := acl.TableToJSON(nil)
+		require.Error(t, err)
+
+		_, err = acl.TableFromJSON(nil)
+		require.Error(t, err)
 	})
 }
 
@@ -39,11 +55,11 @@ func TestBearerTokenJSON(t *testing.T) {
 	exp := generateBearerToken("token")
 
 	t.Run("non empty", func(t *testing.T) {
-		data := acl.BearerTokenToJSON(exp)
-		require.NotNil(t, data)
+		data, err := acl.BearerTokenToJSON(exp)
+		require.NoError(t, err)
 
-		got := acl.BearerTokenFromJSON(data)
-		require.NotNil(t, got)
+		got, err := acl.BearerTokenFromJSON(data)
+		require.NoError(t, err)
 
 		require.Equal(t, exp, got)
 	})

--- a/v2/container/json.go
+++ b/v2/container/json.go
@@ -1,35 +1,36 @@
 package container
 
 import (
+	"errors"
+
 	container "github.com/nspcc-dev/neofs-api-go/v2/container/grpc"
 	"google.golang.org/protobuf/encoding/protojson"
 )
 
-func ContainerToJSON(c *Container) (data []byte) {
+var (
+	errEmptyInput = errors.New("empty input")
+)
+
+func ContainerToJSON(c *Container) ([]byte, error) {
 	if c == nil {
-		return nil
+		return nil, errEmptyInput
 	}
 
 	msg := ContainerToGRPCMessage(c)
 
-	data, err := protojson.MarshalOptions{EmitUnpopulated: true}.Marshal(msg)
-	if err != nil {
-		return nil
-	}
-
-	return
+	return protojson.MarshalOptions{EmitUnpopulated: true}.Marshal(msg)
 }
 
-func ContainerFromJSON(data []byte) *Container {
+func ContainerFromJSON(data []byte) (*Container, error) {
 	if len(data) == 0 {
-		return nil
+		return nil, errEmptyInput
 	}
 
 	msg := new(container.Container)
 
 	if err := protojson.Unmarshal(data, msg); err != nil {
-		return nil
+		return nil, err
 	}
 
-	return ContainerFromGRPCMessage(msg)
+	return ContainerFromGRPCMessage(msg), nil
 }

--- a/v2/container/json_test.go
+++ b/v2/container/json_test.go
@@ -11,12 +11,20 @@ func TestContainerJSON(t *testing.T) {
 	exp := generateContainer("container")
 
 	t.Run("non empty", func(t *testing.T) {
-		data := container.ContainerToJSON(exp)
-		require.NotNil(t, data)
+		data, err := container.ContainerToJSON(exp)
+		require.NoError(t, err)
 
-		got := container.ContainerFromJSON(data)
-		require.NotNil(t, got)
+		got, err := container.ContainerFromJSON(data)
+		require.NoError(t, err)
 
 		require.Equal(t, exp, got)
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		_, err := container.ContainerToJSON(nil)
+		require.Error(t, err)
+
+		_, err = container.ContainerFromJSON(nil)
+		require.Error(t, err)
 	})
 }

--- a/v2/netmap/json.go
+++ b/v2/netmap/json.go
@@ -1,35 +1,36 @@
 package netmap
 
 import (
+	"errors"
+
 	netmap "github.com/nspcc-dev/neofs-api-go/v2/netmap/grpc"
 	"google.golang.org/protobuf/encoding/protojson"
 )
 
-func NodeInfoToJSON(n *NodeInfo) (data []byte) {
+var (
+	errEmptyInput = errors.New("empty input")
+)
+
+func NodeInfoToJSON(n *NodeInfo) ([]byte, error) {
 	if n == nil {
-		return nil
+		return nil, errEmptyInput
 	}
 
 	msg := NodeInfoToGRPCMessage(n)
 
-	data, err := protojson.MarshalOptions{EmitUnpopulated: true}.Marshal(msg)
-	if err != nil {
-		return nil
-	}
-
-	return
+	return protojson.MarshalOptions{EmitUnpopulated: true}.Marshal(msg)
 }
 
-func NodeInfoFromJSON(data []byte) *NodeInfo {
+func NodeInfoFromJSON(data []byte) (*NodeInfo, error) {
 	if len(data) == 0 {
-		return nil
+		return nil, errEmptyInput
 	}
 
 	msg := new(netmap.NodeInfo)
 
 	if err := protojson.Unmarshal(data, msg); err != nil {
-		return nil
+		return nil, err
 	}
 
-	return NodeInfoFromGRPCMessage(msg)
+	return NodeInfoFromGRPCMessage(msg), nil
 }

--- a/v2/netmap/json_test.go
+++ b/v2/netmap/json_test.go
@@ -11,12 +11,20 @@ func TestNodeInfoJSON(t *testing.T) {
 	exp := generateNodeInfo("public key", "/multi/addr", 2)
 
 	t.Run("non empty", func(t *testing.T) {
-		data := netmap.NodeInfoToJSON(exp)
-		require.NotNil(t, data)
+		data, err := netmap.NodeInfoToJSON(exp)
+		require.NoError(t, err)
 
-		got := netmap.NodeInfoFromJSON(data)
-		require.NotNil(t, got)
+		got, err := netmap.NodeInfoFromJSON(data)
+		require.NoError(t, err)
 
 		require.Equal(t, exp, got)
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		_, err := netmap.NodeInfoToJSON(nil)
+		require.Error(t, err)
+
+		_, err = netmap.NodeInfoFromJSON(nil)
+		require.Error(t, err)
 	})
 }


### PR DESCRIPTION
There is a proposal from @im-kulikov to return errors in JSON converters because these converters work with raw `[]byte` and error nil check is more clear for go-developers in case of data marshaling. 