### PR TITLE
sdk/netmap: Refactor types

### DIFF
--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -42,7 +42,7 @@ func TestExample(t *testing.T) {
 
 	policy := new(netmap.PlacementPolicy)
 	policy.SetContainerBackupFactor(2)
-	policy.SetReplicas([]*netmap.Replica{replica})
+	policy.SetReplicas(replica)
 
 	// this container has random nonce and it does not set owner id
 	cnr := container.New(

--- a/pkg/client/netmap.go
+++ b/pkg/client/netmap.go
@@ -3,8 +3,9 @@ package client
 import (
 	"context"
 
+	"github.com/nspcc-dev/neofs-api-go/pkg/netmap"
 	"github.com/nspcc-dev/neofs-api-go/v2/client"
-	"github.com/nspcc-dev/neofs-api-go/v2/netmap"
+	v2netmap "github.com/nspcc-dev/neofs-api-go/v2/netmap"
 	v2signature "github.com/nspcc-dev/neofs-api-go/v2/signature"
 	"github.com/pkg/errors"
 )
@@ -20,7 +21,7 @@ func (c Client) EndpointInfo(ctx context.Context, opts ...CallOption) (*netmap.N
 			return nil, err
 		}
 
-		return resp.GetBody().GetNodeInfo(), nil
+		return netmap.NewNodeInfoFromV2(resp.GetBody().GetNodeInfo()), nil
 	default:
 		return nil, unsupportedProtocolErr
 	}
@@ -41,16 +42,16 @@ func (c Client) Epoch(ctx context.Context, opts ...CallOption) (uint64, error) {
 	}
 }
 
-func (c Client) endpointInfoV2(ctx context.Context, opts ...CallOption) (*netmap.LocalNodeInfoResponse, error) {
+func (c Client) endpointInfoV2(ctx context.Context, opts ...CallOption) (*v2netmap.LocalNodeInfoResponse, error) {
 	// apply all available options
 	callOptions := c.defaultCallOptions()
 	for i := range opts {
 		opts[i].apply(&callOptions)
 	}
 
-	reqBody := new(netmap.LocalNodeInfoRequestBody)
+	reqBody := new(v2netmap.LocalNodeInfoRequestBody)
 
-	req := new(netmap.LocalNodeInfoRequest)
+	req := new(v2netmap.LocalNodeInfoRequest)
 	req.SetBody(reqBody)
 	req.SetMetaHeader(v2MetaHeaderFromOpts(callOptions))
 
@@ -82,19 +83,19 @@ func (c Client) endpointInfoV2(ctx context.Context, opts ...CallOption) (*netmap
 	}
 }
 
-func v2NetmapClientFromOptions(opts *clientOptions) (cli *netmap.Client, err error) {
+func v2NetmapClientFromOptions(opts *clientOptions) (cli *v2netmap.Client, err error) {
 	switch {
 	case opts.grpcOpts.v2NetmapClient != nil:
 		// return value from client cache
 		return opts.grpcOpts.v2NetmapClient, nil
 
 	case opts.grpcOpts.conn != nil:
-		cli, err = netmap.NewClient(netmap.WithGlobalOpts(
+		cli, err = v2netmap.NewClient(v2netmap.WithGlobalOpts(
 			client.WithGRPCConn(opts.grpcOpts.conn)),
 		)
 
 	case opts.addr != "":
-		cli, err = netmap.NewClient(netmap.WithGlobalOpts(
+		cli, err = v2netmap.NewClient(v2netmap.WithGlobalOpts(
 			client.WithNetworkAddress(opts.addr)),
 		)
 

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -25,7 +25,7 @@ func New(opts ...NewOption) *Container {
 	}
 
 	if cnrOptions.policy != nil {
-		cnr.SetPlacementPolicy(cnrOptions.policy)
+		cnr.SetPlacementPolicy(cnrOptions.policy.ToV2())
 	}
 
 	attributes := make([]*container.Attribute, len(cnrOptions.attributes))

--- a/pkg/netmap/clause.go
+++ b/pkg/netmap/clause.go
@@ -9,7 +9,7 @@ import (
 type Clause uint32
 
 const (
-	_ Clause = iota
+	ClauseUnspecified Clause = iota
 
 	// ClauseSame is a selector modifier to select only nodes having the same value of bucket attribute.
 	ClauseSame
@@ -22,7 +22,7 @@ const (
 func ClauseFromV2(c netmap.Clause) Clause {
 	switch c {
 	default:
-		return 0
+		return ClauseUnspecified
 	case netmap.Same:
 		return ClauseSame
 	case netmap.Distinct:

--- a/pkg/netmap/clause.go
+++ b/pkg/netmap/clause.go
@@ -1,0 +1,54 @@
+package netmap
+
+import (
+	"github.com/nspcc-dev/neofs-api-go/v2/netmap"
+)
+
+// Clause is an enumeration of selector modifiers
+// that shows how the node set will be formed.
+type Clause uint32
+
+const (
+	_ Clause = iota
+
+	// ClauseSame is a selector modifier to select only nodes having the same value of bucket attribute.
+	ClauseSame
+
+	// ClauseDistinct is a selector modifier to select nodes having different values of bucket attribute.
+	ClauseDistinct
+)
+
+// ClauseFromV2 converts v2 Clause to Clause.
+func ClauseFromV2(c netmap.Clause) Clause {
+	switch c {
+	default:
+		return 0
+	case netmap.Same:
+		return ClauseSame
+	case netmap.Distinct:
+		return ClauseDistinct
+	}
+}
+
+// ToV2 converts Clause to v2 Clause.
+func (c Clause) ToV2() netmap.Clause {
+	switch c {
+	default:
+		return netmap.UnspecifiedClause
+	case ClauseDistinct:
+		return netmap.Distinct
+	case ClauseSame:
+		return netmap.Same
+	}
+}
+
+func (c Clause) String() string {
+	switch c {
+	default:
+		return "UNSPECIFIED"
+	case ClauseDistinct:
+		return "DISTINCT"
+	case ClauseSame:
+		return "SAME"
+	}
+}

--- a/pkg/netmap/clause_test.go
+++ b/pkg/netmap/clause_test.go
@@ -13,7 +13,7 @@ func TestClauseFromV2(t *testing.T) {
 		cV2 netmap.Clause
 	}{
 		{
-			c:   0,
+			c:   ClauseUnspecified,
 			cV2: netmap.UnspecifiedClause,
 		},
 		{

--- a/pkg/netmap/clause_test.go
+++ b/pkg/netmap/clause_test.go
@@ -1,0 +1,31 @@
+package netmap
+
+import (
+	"testing"
+
+	"github.com/nspcc-dev/neofs-api-go/v2/netmap"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClauseFromV2(t *testing.T) {
+	for _, item := range []struct {
+		c   Clause
+		cV2 netmap.Clause
+	}{
+		{
+			c:   0,
+			cV2: netmap.UnspecifiedClause,
+		},
+		{
+			c:   ClauseSame,
+			cV2: netmap.Same,
+		},
+		{
+			c:   ClauseDistinct,
+			cV2: netmap.Distinct,
+		},
+	} {
+		require.Equal(t, item.c, ClauseFromV2(item.cV2))
+		require.Equal(t, item.cV2, item.c.ToV2())
+	}
+}

--- a/pkg/netmap/context.go
+++ b/pkg/netmap/context.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 
 	"github.com/nspcc-dev/hrw"
-	"github.com/nspcc-dev/neofs-api-go/v2/netmap"
 )
 
 // Context contains references to named filters and cached numeric values.
@@ -12,14 +11,14 @@ type Context struct {
 	// Netmap is a netmap structure to operate on.
 	Netmap *Netmap
 	// Filters stores processed filters.
-	Filters map[string]*netmap.Filter
+	Filters map[string]*Filter
 	// Selectors stores processed selectors.
-	Selectors map[string]*netmap.Selector
+	Selectors map[string]*Selector
 	// Selections stores result of selector processing.
 	Selections map[string][]Nodes
 
 	// numCache stores parsed numeric values.
-	numCache map[*netmap.Filter]uint64
+	numCache map[*Filter]uint64
 	// pivot is a seed for HRW.
 	pivot []byte
 	// pivotHash is a saved HRW hash of pivot
@@ -50,11 +49,11 @@ var (
 func NewContext(nm *Netmap) *Context {
 	return &Context{
 		Netmap:     nm,
-		Filters:    make(map[string]*netmap.Filter),
-		Selectors:  make(map[string]*netmap.Selector),
+		Filters:    make(map[string]*Filter),
+		Selectors:  make(map[string]*Selector),
 		Selections: make(map[string][]Nodes),
 
-		numCache:   make(map[*netmap.Filter]uint64),
+		numCache:   make(map[*Filter]uint64),
 		aggregator: newMeanIQRAgg,
 		weightFunc: GetDefaultWeightFunc(nm.Nodes),
 	}

--- a/pkg/netmap/filter.go
+++ b/pkg/netmap/filter.go
@@ -196,11 +196,7 @@ func (f *Filter) SetOperation(op Operation) {
 		SetOp(op.ToV2())
 }
 
-// InnerFilters returns list of inner filters.
-func (f *Filter) InnerFilters() []*Filter {
-	fs := (*netmap.Filter)(f).
-		GetFilters()
-
+func filtersFromV2(fs []*netmap.Filter) []*Filter {
 	res := make([]*Filter, 0, len(fs))
 
 	for i := range fs {
@@ -210,14 +206,26 @@ func (f *Filter) InnerFilters() []*Filter {
 	return res
 }
 
-// SetInnerFilters sets list of inner filters.
-func (f *Filter) SetInnerFilters(fs ...*Filter) {
+// InnerFilters returns list of inner filters.
+func (f *Filter) InnerFilters() []*Filter {
+	return filtersFromV2(
+		(*netmap.Filter)(f).
+			GetFilters(),
+	)
+}
+
+func filtersToV2(fs []*Filter) []*netmap.Filter {
 	fsV2 := make([]*netmap.Filter, 0, len(fs))
 
 	for i := range fs {
 		fsV2 = append(fsV2, fs[i].ToV2())
 	}
 
+	return fsV2
+}
+
+// SetInnerFilters sets list of inner filters.
+func (f *Filter) SetInnerFilters(fs ...*Filter) {
 	(*netmap.Filter)(f).
-		SetFilters(fsV2)
+		SetFilters(filtersToV2(fs))
 }

--- a/pkg/netmap/filter.go
+++ b/pkg/netmap/filter.go
@@ -7,6 +7,9 @@ import (
 	"github.com/nspcc-dev/neofs-api-go/v2/netmap"
 )
 
+// Filter represents v2-compatible netmap filter.
+type Filter netmap.Filter
+
 // MainFilterName is a name of the filter
 // which points to the whole netmap.
 const MainFilterName = "*"
@@ -126,4 +129,95 @@ func (c *Context) matchKeyValue(f *netmap.Filter, b *Node) bool {
 	}
 	// will not happen if context was created from f (maybe panic?)
 	return false
+}
+
+// NewFilter creates and returns new Filter instance.
+func NewFilter() *Filter {
+	return NewFilterFromV2(new(netmap.Filter))
+}
+
+// NewFilterFromV2 converts v2 Filter to Filter.
+func NewFilterFromV2(f *netmap.Filter) *Filter {
+	return (*Filter)(f)
+}
+
+// ToV2 converts Filter to v2 Filter.
+func (f *Filter) ToV2() *netmap.Filter {
+	return (*netmap.Filter)(f)
+}
+
+// Key returns key to filter.
+func (f *Filter) Key() string {
+	return (*netmap.Filter)(f).
+		GetKey()
+}
+
+// SetKey sets key to filter.
+func (f *Filter) SetKey(key string) {
+	(*netmap.Filter)(f).
+		SetKey(key)
+}
+
+// Value returns value to match.
+func (f *Filter) Value() string {
+	return (*netmap.Filter)(f).
+		GetValue()
+}
+
+// SetValue sets value to match.
+func (f *Filter) SetValue(val string) {
+	(*netmap.Filter)(f).
+		SetValue(val)
+}
+
+// Name returns filter name.
+func (f *Filter) Name() string {
+	return (*netmap.Filter)(f).
+		GetName()
+}
+
+// SetName sets filter name.
+func (f *Filter) SetName(name string) {
+	(*netmap.Filter)(f).
+		SetName(name)
+}
+
+// Operation returns filtering operation.
+func (f *Filter) Operation() Operation {
+	return OperationFromV2(
+		(*netmap.Filter)(f).
+			GetOp(),
+	)
+}
+
+// SetOperation sets filtering operation.
+func (f *Filter) SetOperation(op Operation) {
+	(*netmap.Filter)(f).
+		SetOp(op.ToV2())
+}
+
+// InnerFilters returns list of inner filters.
+func (f *Filter) InnerFilters() []*Filter {
+	fs := (*netmap.Filter)(f).
+		GetFilters()
+
+	res := make([]*Filter, 0, len(fs))
+
+	for i := range fs {
+		res = append(res, NewFilterFromV2(fs[i]))
+	}
+
+	return res
+}
+
+// SetInnerFilters sets list of inner filters.
+func (f *Filter) SetInnerFilters(fs ...*Filter) {
+	fsV2 := make([]*netmap.Filter, 0, len(fs))
+
+	for i := range fs {
+		fsV2 = append(fsV2, fs[i].ToV2())
+	}
+
+	(*netmap.Filter)(f).
+		SetFilters(fsV2)
 }

--- a/pkg/netmap/filter_test.go
+++ b/pkg/netmap/filter_test.go
@@ -201,3 +201,71 @@ func TestFilter_Match(t *testing.T) {
 		require.False(t, c.applyFilter("Main", n))
 	})
 }
+
+func testFilter() *Filter {
+	f := NewFilter()
+	f.SetOperation(OpGE)
+	f.SetName("name")
+	f.SetKey("key")
+	f.SetValue("value")
+
+	return f
+}
+
+func TestFilterFromV2(t *testing.T) {
+	fV2 := new(netmap.Filter)
+	fV2.SetOp(netmap.GE)
+	fV2.SetName("name")
+	fV2.SetKey("key")
+	fV2.SetValue("value")
+
+	f := NewFilterFromV2(fV2)
+
+	require.Equal(t, fV2, f.ToV2())
+}
+
+func TestFilter_Key(t *testing.T) {
+	f := NewFilter()
+	key := "some key"
+
+	f.SetKey(key)
+
+	require.Equal(t, key, f.Key())
+}
+
+func TestFilter_Value(t *testing.T) {
+	f := NewFilter()
+	val := "some value"
+
+	f.SetValue(val)
+
+	require.Equal(t, val, f.Value())
+}
+
+func TestFilter_Name(t *testing.T) {
+	f := NewFilter()
+	name := "some name"
+
+	f.SetName(name)
+
+	require.Equal(t, name, f.Name())
+}
+
+func TestFilter_Operation(t *testing.T) {
+	f := NewFilter()
+	op := OpGE
+
+	f.SetOperation(op)
+
+	require.Equal(t, op, f.Operation())
+}
+
+func TestFilter_InnerFilters(t *testing.T) {
+	f := NewFilter()
+
+	f1, f2 := testFilter(), testFilter()
+
+	f.SetInnerFilters(f1, f2)
+
+	require.Equal(t, []*Filter{f1, f2}, f.InnerFilters())
+}

--- a/pkg/netmap/helper_test.go
+++ b/pkg/netmap/helper_test.go
@@ -1,21 +1,17 @@
 package netmap
 
-import (
-	"github.com/nspcc-dev/neofs-api-go/v2/netmap"
-)
-
-func newFilter(name string, k, v string, op netmap.Operation, fs ...*netmap.Filter) *netmap.Filter {
-	f := new(netmap.Filter)
+func newFilter(name string, k, v string, op Operation, fs ...*Filter) *Filter {
+	f := NewFilter()
 	f.SetName(name)
 	f.SetKey(k)
-	f.SetOp(op)
+	f.SetOperation(op)
 	f.SetValue(v)
-	f.SetFilters(fs)
+	f.SetInnerFilters(fs...)
 	return f
 }
 
-func newSelector(name string, attr string, c netmap.Clause, count uint32, filter string) *netmap.Selector {
-	s := new(netmap.Selector)
+func newSelector(name string, attr string, c Clause, count uint32, filter string) *Selector {
+	s := NewSelector()
 	s.SetName(name)
 	s.SetAttribute(attr)
 	s.SetCount(count)
@@ -24,32 +20,32 @@ func newSelector(name string, attr string, c netmap.Clause, count uint32, filter
 	return s
 }
 
-func newPlacementPolicy(bf uint32, rs []*netmap.Replica, ss []*netmap.Selector, fs []*netmap.Filter) *netmap.PlacementPolicy {
-	p := new(netmap.PlacementPolicy)
+func newPlacementPolicy(bf uint32, rs []*Replica, ss []*Selector, fs []*Filter) *PlacementPolicy {
+	p := NewPlacementPolicy()
 	p.SetContainerBackupFactor(bf)
-	p.SetReplicas(rs)
-	p.SetSelectors(ss)
-	p.SetFilters(fs)
+	p.SetReplicas(rs...)
+	p.SetSelectors(ss...)
+	p.SetFilters(fs...)
 	return p
 }
 
-func newReplica(c uint32, s string) *netmap.Replica {
-	r := new(netmap.Replica)
+func newReplica(c uint32, s string) *Replica {
+	r := NewReplica()
 	r.SetCount(c)
 	r.SetSelector(s)
 	return r
 }
 
-func nodeInfoFromAttributes(props ...string) netmap.NodeInfo {
-	attrs := make([]*netmap.Attribute, len(props)/2)
+func nodeInfoFromAttributes(props ...string) NodeInfo {
+	attrs := make([]*NodeAttribute, len(props)/2)
 	for i := range attrs {
-		attrs[i] = new(netmap.Attribute)
+		attrs[i] = NewNodeAttribute()
 		attrs[i].SetKey(props[i*2])
 		attrs[i].SetValue(props[i*2+1])
 	}
-	var n netmap.NodeInfo
-	n.SetAttributes(attrs)
-	return n
+	n := NewNodeInfo()
+	n.SetAttributes(attrs...)
+	return *n
 }
 
 func getTestNode(props ...string) *Node {

--- a/pkg/netmap/netmap.go
+++ b/pkg/netmap/netmap.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/nspcc-dev/hrw"
-	"github.com/nspcc-dev/neofs-api-go/v2/netmap"
 )
 
 // Netmap represents netmap which contains preprocessed nodes.
@@ -43,7 +42,7 @@ func (m *Netmap) GetPlacementVectors(cnt ContainerNodes, pivot []byte) ([]Nodes,
 // GetContainerNodes returns nodes corresponding to each replica.
 // Order of returned nodes corresponds to order of replicas in p.
 // pivot is a seed for HRW sorting.
-func (m *Netmap) GetContainerNodes(p *netmap.PlacementPolicy, pivot []byte) (ContainerNodes, error) {
+func (m *Netmap) GetContainerNodes(p *PlacementPolicy, pivot []byte) (ContainerNodes, error) {
 	c := NewContext(m)
 	c.setPivot(pivot)
 	if err := c.processFilters(p); err != nil {
@@ -52,19 +51,19 @@ func (m *Netmap) GetContainerNodes(p *netmap.PlacementPolicy, pivot []byte) (Con
 	if err := c.processSelectors(p); err != nil {
 		return nil, err
 	}
-	result := make([]Nodes, len(p.GetReplicas()))
-	for i, r := range p.GetReplicas() {
+	result := make([]Nodes, len(p.Replicas()))
+	for i, r := range p.Replicas() {
 		if r == nil {
 			return nil, fmt.Errorf("%w: REPLICA", ErrMissingField)
 		}
-		if r.GetSelector() == "" {
-			for _, s := range p.GetSelectors() {
-				result[i] = append(result[i], flattenNodes(c.Selections[s.GetName()])...)
+		if r.Selector() == "" {
+			for _, s := range p.Selectors() {
+				result[i] = append(result[i], flattenNodes(c.Selections[s.Name()])...)
 			}
 		}
-		nodes, ok := c.Selections[r.GetSelector()]
+		nodes, ok := c.Selections[r.Selector()]
 		if !ok {
-			return nil, fmt.Errorf("%w: REPLICA '%s'", ErrSelectorNotFound, r.GetSelector())
+			return nil, fmt.Errorf("%w: REPLICA '%s'", ErrSelectorNotFound, r.Selector())
 		}
 		result[i] = append(result[i], flattenNodes(nodes)...)
 

--- a/pkg/netmap/node_info.go
+++ b/pkg/netmap/node_info.go
@@ -23,6 +23,19 @@ type (
 	Nodes []*Node
 )
 
+// NodeState is an enumeration of various states of the NeoFS node.
+type NodeState uint32
+
+const (
+	_ NodeState = iota
+
+	// NodeStateOffline is network unavailable state.
+	NodeStateOffline
+
+	// NodeStateOnline is an active state in the network.
+	NodeStateOnline
+)
+
 // Enumeration of well-known attributes.
 const (
 	CapacityAttr = "Capacity"
@@ -97,4 +110,39 @@ func GetBucketWeight(ns Nodes, a aggregator, wf weightFunc) float64 {
 		a.Add(wf(ns[i]))
 	}
 	return a.Compute()
+}
+
+// NodeStateFromV2 converts v2 NodeState to NodeState.
+func NodeStateFromV2(s netmap.NodeState) NodeState {
+	switch s {
+	default:
+		return 0
+	case netmap.Online:
+		return NodeStateOnline
+	case netmap.Offline:
+		return NodeStateOffline
+	}
+}
+
+// ToV2 converts NodeState to v2 NodeState.
+func (s NodeState) ToV2() netmap.NodeState {
+	switch s {
+	default:
+		return netmap.UnspecifiedState
+	case NodeStateOffline:
+		return netmap.Offline
+	case NodeStateOnline:
+		return netmap.Online
+	}
+}
+
+func (s NodeState) String() string {
+	switch s {
+	default:
+		return "UNSPECIFIED"
+	case NodeStateOffline:
+		return "OFFLINE"
+	case NodeStateOnline:
+		return "ONLINE"
+	}
 }

--- a/pkg/netmap/node_info.go
+++ b/pkg/netmap/node_info.go
@@ -29,6 +29,9 @@ type NodeState uint32
 // NodeAttribute represents v2 compatible attribute of the NeoFS Storage Node.
 type NodeAttribute netmap.Attribute
 
+// NodeInfo represents v2 compatible descriptor of the NeoFS node.
+type NodeInfo netmap.NodeInfo
+
 const (
 	_ NodeState = iota
 
@@ -199,4 +202,83 @@ func (a *NodeAttribute) ParentKeys() []string {
 func (a *NodeAttribute) SetParentKeys(keys ...string) {
 	(*netmap.Attribute)(a).
 		SetParents(keys)
+}
+
+// NewNodeInfo creates and returns new NodeInfo instance.
+func NewNodeInfo() *NodeInfo {
+	return NewNodeInfoFromV2(new(netmap.NodeInfo))
+}
+
+// NewNodeInfoFromV2 converts v2 NodeInfo to NodeInfo.
+func NewNodeInfoFromV2(i *netmap.NodeInfo) *NodeInfo {
+	return (*NodeInfo)(i)
+}
+
+// ToV2 converts NodeInfo to v2 NodeInfo.
+func (i *NodeInfo) ToV2() *netmap.NodeInfo {
+	return (*netmap.NodeInfo)(i)
+}
+
+// PublicKey returns public key of the node in a binary format.
+func (i *NodeInfo) PublicKey() []byte {
+	return (*netmap.NodeInfo)(i).
+		GetPublicKey()
+}
+
+// SetPublicKey sets public key of the node in a binary format.
+func (i *NodeInfo) SetPublicKey(key []byte) {
+	(*netmap.NodeInfo)(i).
+		SetPublicKey(key)
+}
+
+// Address returns network endpoint address of the node.
+func (i *NodeInfo) Address() string {
+	return (*netmap.NodeInfo)(i).
+		GetAddress()
+}
+
+// SetAddress sets network endpoint address of the node.
+func (i *NodeInfo) SetAddress(addr string) {
+	(*netmap.NodeInfo)(i).
+		SetAddress(addr)
+}
+
+// Attributes returns list of the node attributes.
+func (i *NodeInfo) Attributes() []*NodeAttribute {
+	as := (*netmap.NodeInfo)(i).
+		GetAttributes()
+
+	res := make([]*NodeAttribute, 0, len(as))
+
+	for i := range as {
+		res = append(res, NewNodeAttributeFromV2(as[i]))
+	}
+
+	return res
+}
+
+// SetAttributes sets list of the node attributes.
+func (i *NodeInfo) SetAttributes(as ...*NodeAttribute) {
+	asV2 := make([]*netmap.Attribute, 0, len(as))
+
+	for i := range as {
+		asV2 = append(asV2, as[i].ToV2())
+	}
+
+	(*netmap.NodeInfo)(i).
+		SetAttributes(asV2)
+}
+
+// State returns node state.
+func (i *NodeInfo) State() NodeState {
+	return NodeStateFromV2(
+		(*netmap.NodeInfo)(i).
+			GetState(),
+	)
+}
+
+// SetState sets node state.
+func (i *NodeInfo) SetState(s NodeState) {
+	(*netmap.NodeInfo)(i).
+		SetState(s.ToV2())
 }

--- a/pkg/netmap/node_info.go
+++ b/pkg/netmap/node_info.go
@@ -16,7 +16,7 @@ type (
 		Price    uint64
 		AttrMap  map[string]string
 
-		InfoV2 *netmap.NodeInfo
+		*NodeInfo
 	}
 
 	// Nodes represents slice of graph leafs.
@@ -57,19 +57,8 @@ func (n Node) Hash() uint64 {
 	return n.ID
 }
 
-// NetworkAddress returns network address
-// of the node in a string format.
-func (n Node) NetworkAddress() string {
-	return n.InfoV2.GetAddress()
-}
-
-// PublicKey returns public key of the node in bytes.
-func (n Node) PublicKey() []byte {
-	return n.InfoV2.GetPublicKey()
-}
-
-// NodesFromV2 converts slice of v2 netmap.NodeInfo to a generic node slice.
-func NodesFromV2(infos []netmap.NodeInfo) Nodes {
+// NodesFromInfo converts slice of NodeInfo to a generic node slice.
+func NodesFromInfo(infos []NodeInfo) Nodes {
 	nodes := make(Nodes, len(infos))
 	for i := range infos {
 		nodes[i] = newNodeV2(i, &infos[i])
@@ -77,21 +66,21 @@ func NodesFromV2(infos []netmap.NodeInfo) Nodes {
 	return nodes
 }
 
-func newNodeV2(index int, ni *netmap.NodeInfo) *Node {
+func newNodeV2(index int, ni *NodeInfo) *Node {
 	n := &Node{
-		ID:      hrw.Hash(ni.GetPublicKey()),
-		Index:   index,
-		AttrMap: make(map[string]string, len(ni.GetAttributes())),
-		InfoV2:  ni,
+		ID:       hrw.Hash(ni.PublicKey()),
+		Index:    index,
+		AttrMap:  make(map[string]string, len(ni.Attributes())),
+		NodeInfo: ni,
 	}
-	for _, attr := range ni.GetAttributes() {
-		switch attr.GetKey() {
+	for _, attr := range ni.Attributes() {
+		switch attr.Key() {
 		case CapacityAttr:
-			n.Capacity, _ = strconv.ParseUint(attr.GetValue(), 10, 64)
+			n.Capacity, _ = strconv.ParseUint(attr.Value(), 10, 64)
 		case PriceAttr:
-			n.Price, _ = strconv.ParseUint(attr.GetValue(), 10, 64)
+			n.Price, _ = strconv.ParseUint(attr.Value(), 10, 64)
 		}
-		n.AttrMap[attr.GetKey()] = attr.GetValue()
+		n.AttrMap[attr.Key()] = attr.Value()
 	}
 	return n
 }

--- a/pkg/netmap/node_info.go
+++ b/pkg/netmap/node_info.go
@@ -26,6 +26,9 @@ type (
 // NodeState is an enumeration of various states of the NeoFS node.
 type NodeState uint32
 
+// NodeAttribute represents v2 compatible attribute of the NeoFS Storage Node.
+type NodeAttribute netmap.Attribute
+
 const (
 	_ NodeState = iota
 
@@ -145,4 +148,55 @@ func (s NodeState) String() string {
 	case NodeStateOnline:
 		return "ONLINE"
 	}
+}
+
+// NewNodeAttribute creates and returns new NodeAttribute instance.
+func NewNodeAttribute() *NodeAttribute {
+	return NewNodeAttributeFromV2(new(netmap.Attribute))
+}
+
+// NodeAttributeFromV2 converts v2 node Attribute to NodeAttribute.
+func NewNodeAttributeFromV2(a *netmap.Attribute) *NodeAttribute {
+	return (*NodeAttribute)(a)
+}
+
+// ToV2 converts NodeAttribute to v2 node Attribute.
+func (a *NodeAttribute) ToV2() *netmap.Attribute {
+	return (*netmap.Attribute)(a)
+}
+
+// Key returns key to the node attribute.
+func (a *NodeAttribute) Key() string {
+	return (*netmap.Attribute)(a).
+		GetKey()
+}
+
+// SetKey sets key to the node attribute.
+func (a *NodeAttribute) SetKey(key string) {
+	(*netmap.Attribute)(a).
+		SetKey(key)
+}
+
+// Value returns value of the node attribute.
+func (a *NodeAttribute) Value() string {
+	return (*netmap.Attribute)(a).
+		GetValue()
+}
+
+// SetValue sets value of the node attribute.
+func (a *NodeAttribute) SetValue(val string) {
+	(*netmap.Attribute)(a).
+		SetValue(val)
+}
+
+// ParentKeys returns list of parent keys.
+func (a *NodeAttribute) ParentKeys() []string {
+	return (*netmap.Attribute)(a).
+		GetParents()
+}
+
+// SetParentKeys sets list of parent keys.
+func (a *NodeAttribute) SetParentKeys(keys ...string) {
+	(*netmap.Attribute)(a).
+		SetParents(keys)
 }

--- a/pkg/netmap/node_info.go
+++ b/pkg/netmap/node_info.go
@@ -214,6 +214,21 @@ func NewNodeInfoFromV2(i *netmap.NodeInfo) *NodeInfo {
 	return (*NodeInfo)(i)
 }
 
+// NodeInfoToJSON encodes NodeInfo to JSON format.
+func NodeInfoToJSON(i *NodeInfo) ([]byte, error) {
+	return netmap.NodeInfoToJSON(i.ToV2())
+}
+
+// NodeInfoFromJSON decodes NodeInfo from JSON-encoded data.
+func NodeInfoFromJSON(data []byte) (*NodeInfo, error) {
+	i, err := netmap.NodeInfoFromJSON(data)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewNodeInfoFromV2(i), nil
+}
+
 // ToV2 converts NodeInfo to v2 NodeInfo.
 func (i *NodeInfo) ToV2() *netmap.NodeInfo {
 	return (*netmap.NodeInfo)(i)

--- a/pkg/netmap/node_info_test.go
+++ b/pkg/netmap/node_info_test.go
@@ -140,3 +140,19 @@ func TestNodeInfo_Attributes(t *testing.T) {
 
 	require.Equal(t, as, i.Attributes())
 }
+
+func TestNodeInfoJSON(t *testing.T) {
+	i := NewNodeInfo()
+	i.SetPublicKey([]byte{1, 2, 3})
+	i.SetAddress("some node address")
+	i.SetState(NodeStateOnline)
+	i.SetAttributes(testNodeAttribute(), testNodeAttribute())
+
+	j, err := NodeInfoToJSON(i)
+	require.NoError(t, err)
+
+	i2, err := NodeInfoFromJSON(j)
+	require.NoError(t, err)
+
+	require.Equal(t, i, i2)
+}

--- a/pkg/netmap/node_info_test.go
+++ b/pkg/netmap/node_info_test.go
@@ -19,3 +19,26 @@ func TestNode_NetworkAddress(t *testing.T) {
 
 	require.Equal(t, addr, n.NetworkAddress())
 }
+
+func TestNodeStateFromV2(t *testing.T) {
+	for _, item := range []struct {
+		s   NodeState
+		sV2 netmap.NodeState
+	}{
+		{
+			s:   0,
+			sV2: netmap.UnspecifiedState,
+		},
+		{
+			s:   NodeStateOnline,
+			sV2: netmap.Online,
+		},
+		{
+			s:   NodeStateOffline,
+			sV2: netmap.Offline,
+		},
+	} {
+		require.Equal(t, item.s, NodeStateFromV2(item.sV2))
+		require.Equal(t, item.sV2, item.s.ToV2())
+	}
+}

--- a/pkg/netmap/node_info_test.go
+++ b/pkg/netmap/node_info_test.go
@@ -7,19 +7,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestNode_NetworkAddress(t *testing.T) {
-	addr := "127.0.0.1:8080"
-
-	nV2 := new(netmap.NodeInfo)
-	nV2.SetAddress(addr)
-
-	n := Node{
-		InfoV2: nV2,
-	}
-
-	require.Equal(t, addr, n.NetworkAddress())
-}
-
 func TestNodeStateFromV2(t *testing.T) {
 	for _, item := range []struct {
 		s   NodeState

--- a/pkg/netmap/node_info_test.go
+++ b/pkg/netmap/node_info_test.go
@@ -42,3 +42,41 @@ func TestNodeStateFromV2(t *testing.T) {
 		require.Equal(t, item.sV2, item.s.ToV2())
 	}
 }
+
+func TestNodeAttributeFromV2(t *testing.T) {
+	aV2 := new(netmap.Attribute)
+	aV2.SetKey("key")
+	aV2.SetValue("value")
+	aV2.SetParents([]string{"par1", "par2"})
+
+	a := NewNodeAttributeFromV2(aV2)
+
+	require.Equal(t, aV2, a.ToV2())
+}
+
+func TestNodeAttribute_Key(t *testing.T) {
+	a := NewNodeAttribute()
+	key := "some key"
+
+	a.SetKey(key)
+
+	require.Equal(t, key, a.Key())
+}
+
+func TestNodeAttribute_Value(t *testing.T) {
+	a := NewNodeAttribute()
+	val := "some value"
+
+	a.SetValue(val)
+
+	require.Equal(t, val, a.Value())
+}
+
+func TestNodeAttribute_ParentKeys(t *testing.T) {
+	a := NewNodeAttribute()
+	keys := []string{"par1", "par2"}
+
+	a.SetParentKeys(keys...)
+
+	require.Equal(t, keys, a.ParentKeys())
+}

--- a/pkg/netmap/node_info_test.go
+++ b/pkg/netmap/node_info_test.go
@@ -80,3 +80,63 @@ func TestNodeAttribute_ParentKeys(t *testing.T) {
 
 	require.Equal(t, keys, a.ParentKeys())
 }
+
+func testNodeAttribute() *NodeAttribute {
+	a := new(NodeAttribute)
+	a.SetKey("key")
+	a.SetValue("value")
+	a.SetParentKeys("par1", "par2")
+
+	return a
+}
+
+func TestNodeInfoFromV2(t *testing.T) {
+	iV2 := new(netmap.NodeInfo)
+	iV2.SetPublicKey([]byte{1, 2, 3})
+	iV2.SetAddress("456")
+	iV2.SetState(netmap.Online)
+	iV2.SetAttributes([]*netmap.Attribute{
+		testNodeAttribute().ToV2(),
+		testNodeAttribute().ToV2(),
+	})
+
+	i := NewNodeInfoFromV2(iV2)
+
+	require.Equal(t, iV2, i.ToV2())
+}
+
+func TestNodeInfo_PublicKey(t *testing.T) {
+	i := new(NodeInfo)
+	key := []byte{1, 2, 3}
+
+	i.SetPublicKey(key)
+
+	require.Equal(t, key, i.PublicKey())
+}
+
+func TestNodeInfo_Address(t *testing.T) {
+	i := new(NodeInfo)
+	a := "127.0.0.1:8080"
+
+	i.SetAddress(a)
+
+	require.Equal(t, a, i.Address())
+}
+
+func TestNodeInfo_State(t *testing.T) {
+	i := new(NodeInfo)
+	s := NodeStateOnline
+
+	i.SetState(s)
+
+	require.Equal(t, s, i.State())
+}
+
+func TestNodeInfo_Attributes(t *testing.T) {
+	i := new(NodeInfo)
+	as := []*NodeAttribute{testNodeAttribute(), testNodeAttribute()}
+
+	i.SetAttributes(as...)
+
+	require.Equal(t, as, i.Attributes())
+}

--- a/pkg/netmap/operation.go
+++ b/pkg/netmap/operation.go
@@ -1,0 +1,107 @@
+package netmap
+
+import (
+	"github.com/nspcc-dev/neofs-api-go/v2/netmap"
+)
+
+// Operation is an enumeration of v2-compatible filtering operations.
+type Operation uint32
+
+const (
+	_ Operation = iota
+
+	// OpEQ is an "Equal" operation.
+	OpEQ
+
+	// OpNE is a "Not equal" operation.
+	OpNE
+
+	// OpGT is a "Greater than" operation.
+	OpGT
+
+	// OpGE is a "Greater than or equal to" operation.
+	OpGE
+
+	// OpLT is a "Less than" operation.
+	OpLT
+
+	// OpLE is a "Less than or equal to" operation.
+	OpLE
+
+	// OpOR is an "OR" operation.
+	OpOR
+
+	// OpAND is an "AND" operation.
+	OpAND
+)
+
+// OperationFromV2 converts v2 Operation to Operation.
+func OperationFromV2(op netmap.Operation) Operation {
+	switch op {
+	default:
+		return 0
+	case netmap.OR:
+		return OpOR
+	case netmap.AND:
+		return OpAND
+	case netmap.GE:
+		return OpGE
+	case netmap.GT:
+		return OpGT
+	case netmap.LE:
+		return OpLE
+	case netmap.LT:
+		return OpLT
+	case netmap.EQ:
+		return OpEQ
+	case netmap.NE:
+		return OpNE
+	}
+}
+
+// ToV2 converts Operation to v2 Operation.
+func (op Operation) ToV2() netmap.Operation {
+	switch op {
+	default:
+		return netmap.UnspecifiedOperation
+	case OpOR:
+		return netmap.OR
+	case OpAND:
+		return netmap.AND
+	case OpGE:
+		return netmap.GE
+	case OpGT:
+		return netmap.GT
+	case OpLE:
+		return netmap.LE
+	case OpLT:
+		return netmap.LT
+	case OpEQ:
+		return netmap.EQ
+	case OpNE:
+		return netmap.NE
+	}
+}
+
+func (op Operation) String() string {
+	switch op {
+	default:
+		return "UNSPECIFIED"
+	case OpNE:
+		return "NE"
+	case OpEQ:
+		return "EQ"
+	case OpLT:
+		return "LT"
+	case OpLE:
+		return "LE"
+	case OpGT:
+		return "GT"
+	case OpGE:
+		return "GE"
+	case OpAND:
+		return "AND"
+	case OpOR:
+		return "OR"
+	}
+}

--- a/pkg/netmap/operation_test.go
+++ b/pkg/netmap/operation_test.go
@@ -1,0 +1,55 @@
+package netmap
+
+import (
+	"testing"
+
+	"github.com/nspcc-dev/neofs-api-go/v2/netmap"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOperationFromV2(t *testing.T) {
+	for _, item := range []struct {
+		op   Operation
+		opV2 netmap.Operation
+	}{
+		{
+			op:   0,
+			opV2: netmap.UnspecifiedOperation,
+		},
+		{
+			op:   OpEQ,
+			opV2: netmap.EQ,
+		},
+		{
+			op:   OpNE,
+			opV2: netmap.NE,
+		},
+		{
+			op:   OpOR,
+			opV2: netmap.OR,
+		},
+		{
+			op:   OpAND,
+			opV2: netmap.AND,
+		},
+		{
+			op:   OpLE,
+			opV2: netmap.LE,
+		},
+		{
+			op:   OpLT,
+			opV2: netmap.LT,
+		},
+		{
+			op:   OpGT,
+			opV2: netmap.GT,
+		},
+		{
+			op:   OpGE,
+			opV2: netmap.GE,
+		},
+	} {
+		require.Equal(t, item.op, OperationFromV2(item.opV2))
+		require.Equal(t, item.opV2, item.op.ToV2())
+	}
+}

--- a/pkg/netmap/policy.go
+++ b/pkg/netmap/policy.go
@@ -6,7 +6,6 @@ import (
 
 // fixme: make types instead of aliases to v2 structures
 type PlacementPolicy = netmap.PlacementPolicy
-type Selector = netmap.Selector
 type Replica = netmap.Replica
 
 func PlacementPolicyToJSON(p *PlacementPolicy) ([]byte, error) {

--- a/pkg/netmap/policy.go
+++ b/pkg/netmap/policy.go
@@ -10,7 +10,6 @@ type Selector = netmap.Selector
 type Filter = netmap.Filter
 type Replica = netmap.Replica
 type Clause = netmap.Clause
-type Operation = netmap.Operation
 
 func PlacementPolicyToJSON(p *PlacementPolicy) ([]byte, error) {
 	return netmap.PlacementPolicyToJSON(p)

--- a/pkg/netmap/policy.go
+++ b/pkg/netmap/policy.go
@@ -4,13 +4,113 @@ import (
 	"github.com/nspcc-dev/neofs-api-go/v2/netmap"
 )
 
-// fixme: make types instead of aliases to v2 structures
-type PlacementPolicy = netmap.PlacementPolicy
+// PlacementPolicy represents v2-compatible placement policy.
+type PlacementPolicy netmap.PlacementPolicy
 
+// PlacementPolicyToJSON encodes PlacementPolicy to JSON format.
 func PlacementPolicyToJSON(p *PlacementPolicy) ([]byte, error) {
-	return netmap.PlacementPolicyToJSON(p)
+	return netmap.PlacementPolicyToJSON(p.ToV2())
 }
 
+// PlacementPolicyFromJSON decodes PlacementPolicy from JSON format.
 func PlacementPolicyFromJSON(data []byte) (*PlacementPolicy, error) {
-	return netmap.PlacementPolicyFromJSON(data)
+	p, err := netmap.PlacementPolicyFromJSON(data)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewPlacementPolicyFromV2(p), nil
+}
+
+// NewPlacementPolicy creates and returns new PlacementPolicy instance.
+func NewPlacementPolicy() *PlacementPolicy {
+	return NewPlacementPolicyFromV2(new(netmap.PlacementPolicy))
+}
+
+// NewPlacementPolicyFromV2 converts v2 PlacementPolicy to PlacementPolicy.
+func NewPlacementPolicyFromV2(f *netmap.PlacementPolicy) *PlacementPolicy {
+	return (*PlacementPolicy)(f)
+}
+
+// ToV2 converts PlacementPolicy to v2 PlacementPolicy.
+func (p *PlacementPolicy) ToV2() *netmap.PlacementPolicy {
+	return (*netmap.PlacementPolicy)(p)
+}
+
+// Replicas returns list of object replica descriptors.
+func (p *PlacementPolicy) Replicas() []*Replica {
+	rs := (*netmap.PlacementPolicy)(p).
+		GetReplicas()
+
+	res := make([]*Replica, 0, len(rs))
+
+	for i := range rs {
+		res = append(res, NewReplicaFromV2(rs[i]))
+	}
+
+	return res
+}
+
+// SetReplicas sets list of object replica descriptors.
+func (p *PlacementPolicy) SetReplicas(rs ...*Replica) {
+	rsV2 := make([]*netmap.Replica, 0, len(rs))
+
+	for i := range rs {
+		rsV2 = append(rsV2, rs[i].ToV2())
+	}
+
+	(*netmap.PlacementPolicy)(p).
+		SetReplicas(rsV2)
+}
+
+// ContainerBackupFactor returns container backup factor.
+func (p *PlacementPolicy) ContainerBackupFactor() uint32 {
+	return (*netmap.PlacementPolicy)(p).
+		GetContainerBackupFactor()
+}
+
+// SetContainerBackupFactor sets container backup factor.
+func (p *PlacementPolicy) SetContainerBackupFactor(f uint32) {
+	(*netmap.PlacementPolicy)(p).
+		SetContainerBackupFactor(f)
+}
+
+// Selector returns set of selectors to form the container's nodes subset.
+func (p *PlacementPolicy) Selectors() []*Selector {
+	rs := (*netmap.PlacementPolicy)(p).
+		GetSelectors()
+
+	res := make([]*Selector, 0, len(rs))
+
+	for i := range rs {
+		res = append(res, NewSelectorFromV2(rs[i]))
+	}
+
+	return res
+}
+
+// SetSelectors sets set of selectors to form the container's nodes subset.
+func (p *PlacementPolicy) SetSelectors(ss ...*Selector) {
+	rsV2 := make([]*netmap.Selector, 0, len(ss))
+
+	for i := range ss {
+		rsV2 = append(rsV2, ss[i].ToV2())
+	}
+
+	(*netmap.PlacementPolicy)(p).
+		SetSelectors(rsV2)
+}
+
+// Filters returns list of named filters to reference in selectors.
+func (p *PlacementPolicy) Filters() []*Filter {
+	return filtersFromV2(
+		(*netmap.PlacementPolicy)(p).
+			GetFilters(),
+	)
+}
+
+// SetFilters sets list of named filters to reference in selectors.
+func (p *PlacementPolicy) SetFilters(fs ...*Filter) {
+	(*netmap.PlacementPolicy)(p).
+		SetFilters(filtersToV2(fs))
 }

--- a/pkg/netmap/policy.go
+++ b/pkg/netmap/policy.go
@@ -7,7 +7,6 @@ import (
 // fixme: make types instead of aliases to v2 structures
 type PlacementPolicy = netmap.PlacementPolicy
 type Selector = netmap.Selector
-type Filter = netmap.Filter
 type Replica = netmap.Replica
 
 func PlacementPolicyToJSON(p *PlacementPolicy) ([]byte, error) {

--- a/pkg/netmap/policy.go
+++ b/pkg/netmap/policy.go
@@ -6,7 +6,6 @@ import (
 
 // fixme: make types instead of aliases to v2 structures
 type PlacementPolicy = netmap.PlacementPolicy
-type Replica = netmap.Replica
 
 func PlacementPolicyToJSON(p *PlacementPolicy) ([]byte, error) {
 	return netmap.PlacementPolicyToJSON(p)

--- a/pkg/netmap/policy.go
+++ b/pkg/netmap/policy.go
@@ -9,7 +9,6 @@ type PlacementPolicy = netmap.PlacementPolicy
 type Selector = netmap.Selector
 type Filter = netmap.Filter
 type Replica = netmap.Replica
-type Clause = netmap.Clause
 
 func PlacementPolicyToJSON(p *PlacementPolicy) ([]byte, error) {
 	return netmap.PlacementPolicyToJSON(p)

--- a/pkg/netmap/policy_test.go
+++ b/pkg/netmap/policy_test.go
@@ -1,0 +1,69 @@
+package netmap
+
+import (
+	"testing"
+
+	"github.com/nspcc-dev/neofs-api-go/v2/netmap"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPlacementPolicyFromV2(t *testing.T) {
+	pV2 := new(netmap.PlacementPolicy)
+
+	pV2.SetReplicas([]*netmap.Replica{
+		testReplica().ToV2(),
+		testReplica().ToV2(),
+	})
+
+	pV2.SetContainerBackupFactor(3)
+
+	pV2.SetSelectors([]*netmap.Selector{
+		testSelector().ToV2(),
+		testSelector().ToV2(),
+	})
+
+	pV2.SetFilters([]*netmap.Filter{
+		testFilter().ToV2(),
+		testFilter().ToV2(),
+	})
+
+	p := NewPlacementPolicyFromV2(pV2)
+
+	require.Equal(t, pV2, p.ToV2())
+}
+
+func TestPlacementPolicy_Replicas(t *testing.T) {
+	p := NewPlacementPolicy()
+	rs := []*Replica{testReplica(), testReplica()}
+
+	p.SetReplicas(rs...)
+
+	require.Equal(t, rs, p.Replicas())
+}
+
+func TestPlacementPolicy_ContainerBackupFactor(t *testing.T) {
+	p := NewPlacementPolicy()
+	f := uint32(3)
+
+	p.SetContainerBackupFactor(f)
+
+	require.Equal(t, f, p.ContainerBackupFactor())
+}
+
+func TestPlacementPolicy_Selectors(t *testing.T) {
+	p := NewPlacementPolicy()
+	ss := []*Selector{testSelector(), testSelector()}
+
+	p.SetSelectors(ss...)
+
+	require.Equal(t, ss, p.Selectors())
+}
+
+func TestPlacementPolicy_Filters(t *testing.T) {
+	p := NewPlacementPolicy()
+	fs := []*Filter{testFilter(), testFilter()}
+
+	p.SetFilters(fs...)
+
+	require.Equal(t, fs, p.Filters())
+}

--- a/pkg/netmap/replica.go
+++ b/pkg/netmap/replica.go
@@ -1,0 +1,47 @@
+package netmap
+
+import (
+	"github.com/nspcc-dev/neofs-api-go/v2/netmap"
+)
+
+// Replica represents v2-compatible object replica descriptor.
+type Replica netmap.Replica
+
+// NewReplica creates and returns new Replica instance.
+func NewReplica() *Replica {
+	return NewReplicaFromV2(new(netmap.Replica))
+}
+
+// NewReplicaFromV2 converts v2 Replica to Replica.
+func NewReplicaFromV2(f *netmap.Replica) *Replica {
+	return (*Replica)(f)
+}
+
+// ToV2 converts Replica to v2 Replica.
+func (r *Replica) ToV2() *netmap.Replica {
+	return (*netmap.Replica)(r)
+}
+
+// Count returns number of object replicas.
+func (r *Replica) Count() uint32 {
+	return (*netmap.Replica)(r).
+		GetCount()
+}
+
+// SetCount sets number of object replicas.
+func (r *Replica) SetCount(c uint32) {
+	(*netmap.Replica)(r).
+		SetCount(c)
+}
+
+// Selector returns name of selector bucket to put replicas.
+func (r *Replica) Selector() string {
+	return (*netmap.Replica)(r).
+		GetSelector()
+}
+
+// SetSelector sets name of selector bucket to put replicas.
+func (r *Replica) SetSelector(s string) {
+	(*netmap.Replica)(r).
+		SetSelector(s)
+}

--- a/pkg/netmap/replica_test.go
+++ b/pkg/netmap/replica_test.go
@@ -7,6 +7,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func testReplica() *Replica {
+	r := new(Replica)
+	r.SetCount(3)
+	r.SetSelector("selector")
+
+	return r
+}
+
 func TestReplicaFromV2(t *testing.T) {
 	rV2 := new(netmap.Replica)
 	rV2.SetCount(3)

--- a/pkg/netmap/replica_test.go
+++ b/pkg/netmap/replica_test.go
@@ -1,0 +1,36 @@
+package netmap
+
+import (
+	"testing"
+
+	"github.com/nspcc-dev/neofs-api-go/v2/netmap"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReplicaFromV2(t *testing.T) {
+	rV2 := new(netmap.Replica)
+	rV2.SetCount(3)
+	rV2.SetSelector("selector")
+
+	r := NewReplicaFromV2(rV2)
+
+	require.Equal(t, rV2, r.ToV2())
+}
+
+func TestReplica_Count(t *testing.T) {
+	r := NewReplica()
+	c := uint32(3)
+
+	r.SetCount(c)
+
+	require.Equal(t, c, r.Count())
+}
+
+func TestReplica_Selector(t *testing.T) {
+	r := NewReplica()
+	s := "some selector"
+
+	r.SetSelector(s)
+
+	require.Equal(t, s, r.Selector())
+}

--- a/pkg/netmap/selector.go
+++ b/pkg/netmap/selector.go
@@ -8,6 +8,9 @@ import (
 	"github.com/nspcc-dev/neofs-api-go/v2/netmap"
 )
 
+// Selector represents v2-compatible netmap selector.
+type Selector netmap.Selector
+
 // processSelectors processes selectors and returns error is any of them is invalid.
 func (c *Context) processSelectors(p *netmap.PlacementPolicy) error {
 	for _, s := range p.GetSelectors() {
@@ -117,4 +120,81 @@ func (c *Context) getSelectionBase(s *netmap.Selector) []nodeAttrPair {
 		}
 	}
 	return result
+}
+
+// NewSelector creates and returns new Selector instance.
+func NewSelector() *Selector {
+	return NewSelectorFromV2(new(netmap.Selector))
+}
+
+// NewSelectorFromV2 converts v2 Selector to Selector.
+func NewSelectorFromV2(f *netmap.Selector) *Selector {
+	return (*Selector)(f)
+}
+
+// ToV2 converts Selector to v2 Selector.
+func (s *Selector) ToV2() *netmap.Selector {
+	return (*netmap.Selector)(s)
+}
+
+// Name returns selector name.
+func (s *Selector) Name() string {
+	return (*netmap.Selector)(s).
+		GetName()
+}
+
+// SetName sets selector name.
+func (s *Selector) SetName(name string) {
+	(*netmap.Selector)(s).
+		SetName(name)
+}
+
+// Count returns count of nodes to select from bucket.
+func (s *Selector) Count() uint32 {
+	return (*netmap.Selector)(s).
+		GetCount()
+}
+
+// SetCount sets count of nodes to select from bucket.
+func (s *Selector) SetCount(c uint32) {
+	(*netmap.Selector)(s).
+		SetCount(c)
+}
+
+// Clause returns modifier showing how to form a bucket.
+func (s *Selector) Clause() Clause {
+	return ClauseFromV2(
+		(*netmap.Selector)(s).
+			GetClause(),
+	)
+}
+
+// SetClause sets modifier showing how to form a bucket.
+func (s *Selector) SetClause(c Clause) {
+	(*netmap.Selector)(s).
+		SetClause(c.ToV2())
+}
+
+// Attribute returns attribute bucket to select from.
+func (s *Selector) Attribute() string {
+	return (*netmap.Selector)(s).
+		GetAttribute()
+}
+
+// SetAttribute sets attribute bucket to select from.
+func (s *Selector) SetAttribute(a string) {
+	(*netmap.Selector)(s).
+		SetAttribute(a)
+}
+
+// Filter returns filter reference to select from.
+func (s *Selector) Filter() string {
+	return (*netmap.Selector)(s).
+		GetFilter()
+}
+
+// SetFilter sets filter reference to select from.
+func (s *Selector) SetFilter(f string) {
+	(*netmap.Selector)(s).
+		SetFilter(f)
 }

--- a/pkg/netmap/selector_test.go
+++ b/pkg/netmap/selector_test.go
@@ -239,6 +239,17 @@ func TestPlacementPolicy_ProcessSelectorsInvalid(t *testing.T) {
 	}
 }
 
+func testSelector() *Selector {
+	s := new(Selector)
+	s.SetName("name")
+	s.SetCount(3)
+	s.SetFilter("filter")
+	s.SetAttribute("attribute")
+	s.SetClause(ClauseDistinct)
+
+	return s
+}
+
 func TestSelectorFromV2(t *testing.T) {
 	sV2 := new(netmap.Selector)
 	sV2.SetName("name")

--- a/pkg/netmap/selector_test.go
+++ b/pkg/netmap/selector_test.go
@@ -238,3 +238,61 @@ func TestPlacementPolicy_ProcessSelectorsInvalid(t *testing.T) {
 		})
 	}
 }
+
+func TestSelectorFromV2(t *testing.T) {
+	sV2 := new(netmap.Selector)
+	sV2.SetName("name")
+	sV2.SetCount(3)
+	sV2.SetClause(netmap.Distinct)
+	sV2.SetAttribute("attribute")
+	sV2.SetFilter("filter")
+
+	s := NewSelectorFromV2(sV2)
+
+	require.Equal(t, sV2, s.ToV2())
+}
+
+func TestSelector_Name(t *testing.T) {
+	s := NewSelector()
+	name := "some name"
+
+	s.SetName(name)
+
+	require.Equal(t, name, s.Name())
+}
+
+func TestSelector_Count(t *testing.T) {
+	s := NewSelector()
+	c := uint32(3)
+
+	s.SetCount(c)
+
+	require.Equal(t, c, s.Count())
+}
+
+func TestSelector_Clause(t *testing.T) {
+	s := NewSelector()
+	c := ClauseSame
+
+	s.SetClause(c)
+
+	require.Equal(t, c, s.Clause())
+}
+
+func TestSelector_Attribute(t *testing.T) {
+	s := NewSelector()
+	a := "some attribute"
+
+	s.SetAttribute(a)
+
+	require.Equal(t, a, s.Attribute())
+}
+
+func TestSelector_Filter(t *testing.T) {
+	s := NewSelector()
+	f := "some filter"
+
+	s.SetFilter(f)
+
+	require.Equal(t, f, s.Filter())
+}


### PR DESCRIPTION
Replace type aliases to v2 types with full-fledged v2-compatible implementation.

- [x] Operation

- [x] Clause

- [x] Filter

- [x] Selector

- [x] Replica

- [x] PlacementPolicy

- [x] NodeInfo