### PR TITLE
Implement binary and JSON encoders/decoders

### DIFF
--- a/pkg/accounting/decimal.go
+++ b/pkg/accounting/decimal.go
@@ -4,6 +4,39 @@ import (
 	"github.com/nspcc-dev/neofs-api-go/v2/accounting"
 )
 
-type Decimal struct {
-	accounting.Decimal
+// Decimal represents v2-compatible decimal number.
+type Decimal accounting.Decimal
+
+// NewDecimal creates, initializes and returns blank Decimal instance.
+func NewDecimal() *Decimal {
+	return NewDecimalFromV2(new(accounting.Decimal))
+}
+
+// NewDecimalFromV2 converts v2 Decimal to Decimal.
+func NewDecimalFromV2(d *accounting.Decimal) *Decimal {
+	return (*Decimal)(d)
+}
+
+// Value returns value of the decimal number.
+func (d *Decimal) Value() int64 {
+	return (*accounting.Decimal)(d).
+		GetValue()
+}
+
+// SetValue sets value of the decimal number.
+func (d *Decimal) SetValue(v int64) {
+	(*accounting.Decimal)(d).
+		SetValue(v)
+}
+
+// Precision returns precision of the decimal number.
+func (d *Decimal) Precision() uint32 {
+	return (*accounting.Decimal)(d).
+		GetPrecision()
+}
+
+// SetPrecision sets precision of the decimal number.
+func (d *Decimal) SetPrecision(p uint32) {
+	(*accounting.Decimal)(d).
+		SetPrecision(p)
 }

--- a/pkg/accounting/decimal.go
+++ b/pkg/accounting/decimal.go
@@ -40,3 +40,35 @@ func (d *Decimal) SetPrecision(p uint32) {
 	(*accounting.Decimal)(d).
 		SetPrecision(p)
 }
+
+// Marshal marshals Decimal into a protobuf binary form.
+//
+// Buffer is allocated when the argument is empty.
+// Otherwise, the first buffer is used.
+func (d *Decimal) Marshal(b ...[]byte) ([]byte, error) {
+	var buf []byte
+	if len(b) > 0 {
+		buf = b[0]
+	}
+
+	return (*accounting.Decimal)(d).
+		StableMarshal(buf)
+}
+
+// Unmarshal unmarshals protobuf binary representation of Decimal.
+func (d *Decimal) Unmarshal(data []byte) error {
+	return (*accounting.Decimal)(d).
+		Unmarshal(data)
+}
+
+// MarshalJSON encodes Decimal to protobuf JSON format.
+func (d *Decimal) MarshalJSON() ([]byte, error) {
+	return (*accounting.Decimal)(d).
+		MarshalJSON()
+}
+
+// UnmarshalJSON decodes Decimal from protobuf JSON format.
+func (d *Decimal) UnmarshalJSON(data []byte) error {
+	return (*accounting.Decimal)(d).
+		UnmarshalJSON(data)
+}

--- a/pkg/accounting/decimal_test.go
+++ b/pkg/accounting/decimal_test.go
@@ -1,0 +1,25 @@
+package accounting
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecimal_Value(t *testing.T) {
+	d := NewDecimal()
+
+	v := int64(3)
+	d.SetValue(v)
+
+	require.Equal(t, v, d.Value())
+}
+
+func TestDecimal_Precision(t *testing.T) {
+	d := NewDecimal()
+
+	p := uint32(3)
+	d.SetPrecision(p)
+
+	require.Equal(t, p, d.Precision())
+}

--- a/pkg/accounting/decimal_test.go
+++ b/pkg/accounting/decimal_test.go
@@ -23,3 +23,29 @@ func TestDecimal_Precision(t *testing.T) {
 
 	require.Equal(t, p, d.Precision())
 }
+
+func TestDecimalEncoding(t *testing.T) {
+	d := NewDecimal()
+	d.SetValue(1)
+	d.SetPrecision(2)
+
+	t.Run("binary", func(t *testing.T) {
+		data, err := d.Marshal()
+		require.NoError(t, err)
+
+		d2 := NewDecimal()
+		require.NoError(t, d2.Unmarshal(data))
+
+		require.Equal(t, d, d2)
+	})
+
+	t.Run("json", func(t *testing.T) {
+		data, err := d.MarshalJSON()
+		require.NoError(t, err)
+
+		d2 := NewDecimal()
+		require.NoError(t, d2.UnmarshalJSON(data))
+
+		require.Equal(t, d, d2)
+	})
+}

--- a/pkg/acl/eacl/filter_test.go
+++ b/pkg/acl/eacl/filter_test.go
@@ -35,3 +35,27 @@ func TestFilter(t *testing.T) {
 		require.Equal(t, new(Filter), NewFilterFromV2(nil))
 	})
 }
+
+func TestFilterEncoding(t *testing.T) {
+	f := newObjectFilter(MatchStringEqual, "key", "value")
+
+	t.Run("binary", func(t *testing.T) {
+		data, err := f.Marshal()
+		require.NoError(t, err)
+
+		f2 := NewFilter()
+		require.NoError(t, f2.Unmarshal(data))
+
+		require.Equal(t, f, f2)
+	})
+
+	t.Run("json", func(t *testing.T) {
+		data, err := f.MarshalJSON()
+		require.NoError(t, err)
+
+		d2 := NewFilter()
+		require.NoError(t, d2.UnmarshalJSON(data))
+
+		require.Equal(t, f, d2)
+	})
+}

--- a/pkg/acl/eacl/record.go
+++ b/pkg/acl/eacl/record.go
@@ -162,3 +162,47 @@ func NewRecordFromV2(record *v2acl.Record) *Record {
 
 	return r
 }
+
+// Marshal marshals Record into a protobuf binary form.
+//
+// Buffer is allocated when the argument is empty.
+// Otherwise, the first buffer is used.
+func (r *Record) Marshal(b ...[]byte) ([]byte, error) {
+	var buf []byte
+	if len(b) > 0 {
+		buf = b[0]
+	}
+
+	return r.ToV2().
+		StableMarshal(buf)
+}
+
+// Unmarshal unmarshals protobuf binary representation of Record.
+func (r *Record) Unmarshal(data []byte) error {
+	fV2 := new(v2acl.Record)
+	if err := fV2.Unmarshal(data); err != nil {
+		return err
+	}
+
+	*r = *NewRecordFromV2(fV2)
+
+	return nil
+}
+
+// MarshalJSON encodes Record to protobuf JSON format.
+func (r *Record) MarshalJSON() ([]byte, error) {
+	return r.ToV2().
+		MarshalJSON()
+}
+
+// UnmarshalJSON decodes Record from protobuf JSON format.
+func (r *Record) UnmarshalJSON(data []byte) error {
+	tV2 := new(v2acl.Record)
+	if err := tV2.UnmarshalJSON(data); err != nil {
+		return err
+	}
+
+	*r = *NewRecordFromV2(tV2)
+
+	return nil
+}

--- a/pkg/acl/eacl/record_test.go
+++ b/pkg/acl/eacl/record_test.go
@@ -71,3 +71,31 @@ func TestRecord_AddFilter(t *testing.T) {
 
 	require.Equal(t, filters, r.Filters())
 }
+
+func TestRecordEncoding(t *testing.T) {
+	r := NewRecord()
+	r.SetOperation(OperationHead)
+	r.SetAction(ActionDeny)
+	r.AddObjectAttributeFilter(MatchStringEqual, "key", "value")
+	r.AddTarget(RoleSystem, test.DecodeKey(-1).PublicKey)
+
+	t.Run("binary", func(t *testing.T) {
+		data, err := r.Marshal()
+		require.NoError(t, err)
+
+		r2 := NewRecord()
+		require.NoError(t, r2.Unmarshal(data))
+
+		require.Equal(t, r, r2)
+	})
+
+	t.Run("json", func(t *testing.T) {
+		data, err := r.MarshalJSON()
+		require.NoError(t, err)
+
+		r2 := NewRecord()
+		require.NoError(t, r2.UnmarshalJSON(data))
+
+		require.Equal(t, r, r2)
+	})
+}

--- a/pkg/acl/eacl/table.go
+++ b/pkg/acl/eacl/table.go
@@ -111,3 +111,47 @@ func NewTableFromV2(table *v2acl.Table) *Table {
 
 	return t
 }
+
+// Marshal marshals Table into a protobuf binary form.
+//
+// Buffer is allocated when the argument is empty.
+// Otherwise, the first buffer is used.
+func (t *Table) Marshal(b ...[]byte) ([]byte, error) {
+	var buf []byte
+	if len(b) > 0 {
+		buf = b[0]
+	}
+
+	return t.ToV2().
+		StableMarshal(buf)
+}
+
+// Unmarshal unmarshals protobuf binary representation of Table.
+func (t *Table) Unmarshal(data []byte) error {
+	fV2 := new(v2acl.Table)
+	if err := fV2.Unmarshal(data); err != nil {
+		return err
+	}
+
+	*t = *NewTableFromV2(fV2)
+
+	return nil
+}
+
+// MarshalJSON encodes Table to protobuf JSON format.
+func (t *Table) MarshalJSON() ([]byte, error) {
+	return t.ToV2().
+		MarshalJSON()
+}
+
+// UnmarshalJSON decodes Table from protobuf JSON format.
+func (t *Table) UnmarshalJSON(data []byte) error {
+	tV2 := new(v2acl.Table)
+	if err := tV2.UnmarshalJSON(data); err != nil {
+		return err
+	}
+
+	*t = *NewTableFromV2(tV2)
+
+	return nil
+}

--- a/pkg/acl/eacl/table_test.go
+++ b/pkg/acl/eacl/table_test.go
@@ -78,3 +78,30 @@ func TestTable_AddRecord(t *testing.T) {
 
 	require.Equal(t, records, table.Records())
 }
+
+func TestRecordEncoding(t *testing.T) {
+	tab := eacl.NewTable()
+	tab.AddRecord(
+		eacl.CreateRecord(eacl.ActionDeny, eacl.OperationHead),
+	)
+
+	t.Run("binary", func(t *testing.T) {
+		data, err := tab.Marshal()
+		require.NoError(t, err)
+
+		tab2 := eacl.NewTable()
+		require.NoError(t, tab2.Unmarshal(data))
+
+		require.Equal(t, tab, tab2)
+	})
+
+	t.Run("json", func(t *testing.T) {
+		data, err := tab.MarshalJSON()
+		require.NoError(t, err)
+
+		r2 := eacl.NewTable()
+		require.NoError(t, r2.UnmarshalJSON(data))
+
+		require.Equal(t, tab, r2)
+	})
+}

--- a/pkg/acl/eacl/target.go
+++ b/pkg/acl/eacl/target.go
@@ -14,8 +14,16 @@ type Target struct {
 	keys []ecdsa.PublicKey
 }
 
+func (t *Target) SetKeys(keys ...ecdsa.PublicKey) {
+	t.keys = keys
+}
+
 func (t Target) Keys() []ecdsa.PublicKey {
 	return t.keys
+}
+
+func (t *Target) SetRole(r Role) {
+	t.role = r
 }
 
 func (t Target) Role() Role {
@@ -37,6 +45,10 @@ func (t *Target) ToV2() *v2acl.Target {
 	return target
 }
 
+func NewTarget() *Target {
+	return NewTargetFromV2(new(v2acl.Target))
+}
+
 func NewTargetFromV2(target *v2acl.Target) *Target {
 	t := new(Target)
 
@@ -53,4 +65,48 @@ func NewTargetFromV2(target *v2acl.Target) *Target {
 	}
 
 	return t
+}
+
+// Marshal marshals Target into a protobuf binary form.
+//
+// Buffer is allocated when the argument is empty.
+// Otherwise, the first buffer is used.
+func (t *Target) Marshal(b ...[]byte) ([]byte, error) {
+	var buf []byte
+	if len(b) > 0 {
+		buf = b[0]
+	}
+
+	return t.ToV2().
+		StableMarshal(buf)
+}
+
+// Unmarshal unmarshals protobuf binary representation of Target.
+func (t *Target) Unmarshal(data []byte) error {
+	fV2 := new(v2acl.Target)
+	if err := fV2.Unmarshal(data); err != nil {
+		return err
+	}
+
+	*t = *NewTargetFromV2(fV2)
+
+	return nil
+}
+
+// MarshalJSON encodes Target to protobuf JSON format.
+func (t *Target) MarshalJSON() ([]byte, error) {
+	return t.ToV2().
+		MarshalJSON()
+}
+
+// UnmarshalJSON decodes Target from protobuf JSON format.
+func (t *Target) UnmarshalJSON(data []byte) error {
+	tV2 := new(v2acl.Target)
+	if err := tV2.UnmarshalJSON(data); err != nil {
+		return err
+	}
+
+	*t = *NewTargetFromV2(tV2)
+
+	return nil
 }

--- a/pkg/acl/eacl/target_test.go
+++ b/pkg/acl/eacl/target_test.go
@@ -36,3 +36,29 @@ func TestTarget(t *testing.T) {
 		require.Equal(t, new(Target), NewTargetFromV2(nil))
 	})
 }
+
+func TestTargetEncoding(t *testing.T) {
+	tar := NewTarget()
+	tar.SetRole(RoleSystem)
+	tar.SetKeys(test.DecodeKey(-1).PublicKey)
+
+	t.Run("binary", func(t *testing.T) {
+		data, err := tar.Marshal()
+		require.NoError(t, err)
+
+		tar2 := NewTarget()
+		require.NoError(t, tar2.Unmarshal(data))
+
+		require.Equal(t, tar, tar2)
+	})
+
+	t.Run("json", func(t *testing.T) {
+		data, err := tar.MarshalJSON()
+		require.NoError(t, err)
+
+		tar2 := NewTarget()
+		require.NoError(t, tar2.UnmarshalJSON(data))
+
+		require.Equal(t, tar, tar2)
+	})
+}

--- a/pkg/checksum.go
+++ b/pkg/checksum.go
@@ -77,3 +77,35 @@ func (c *Checksum) ToV2() *refs.Checksum {
 func EqualChecksums(cs1, cs2 *Checksum) bool {
 	return cs1.GetType() == cs2.GetType() && bytes.Equal(cs1.GetSum(), cs2.GetSum())
 }
+
+// Marshal marshals Checksum into a protobuf binary form.
+//
+// Buffer is allocated when the argument is empty.
+// Otherwise, the first buffer is used.
+func (c *Checksum) Marshal(b ...[]byte) ([]byte, error) {
+	var buf []byte
+	if len(b) > 0 {
+		buf = b[0]
+	}
+
+	return (*refs.Checksum)(c).
+		StableMarshal(buf)
+}
+
+// Unmarshal unmarshals protobuf binary representation of Checksum.
+func (c *Checksum) Unmarshal(data []byte) error {
+	return (*refs.Checksum)(c).
+		Unmarshal(data)
+}
+
+// MarshalJSON encodes Checksum to protobuf JSON format.
+func (c *Checksum) MarshalJSON() ([]byte, error) {
+	return (*refs.Checksum)(c).
+		MarshalJSON()
+}
+
+// UnmarshalJSON decodes Checksum from protobuf JSON format.
+func (c *Checksum) UnmarshalJSON(data []byte) error {
+	return (*refs.Checksum)(c).
+		UnmarshalJSON(data)
+}

--- a/pkg/checksum_test.go
+++ b/pkg/checksum_test.go
@@ -9,6 +9,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func randSHA256(t *testing.T) [sha256.Size]byte {
+	cSHA256 := [sha256.Size]byte{}
+	_, err := rand.Read(cSHA256[:])
+	require.NoError(t, err)
+
+	return cSHA256
+}
+
 func TestChecksum(t *testing.T) {
 	c := NewChecksum()
 
@@ -57,4 +65,29 @@ func TestEqualChecksums(t *testing.T) {
 	cs2.SetSHA256(csSHA)
 
 	require.False(t, EqualChecksums(cs1, cs2))
+}
+
+func TestChecksumEncoding(t *testing.T) {
+	cs := NewChecksum()
+	cs.SetSHA256(randSHA256(t))
+
+	t.Run("binary", func(t *testing.T) {
+		data, err := cs.Marshal()
+		require.NoError(t, err)
+
+		c2 := NewChecksum()
+		require.NoError(t, c2.Unmarshal(data))
+
+		require.Equal(t, cs, c2)
+	})
+
+	t.Run("json", func(t *testing.T) {
+		data, err := cs.MarshalJSON()
+		require.NoError(t, err)
+
+		cs2 := NewChecksum()
+		require.NoError(t, cs2.UnmarshalJSON(data))
+
+		require.Equal(t, cs, cs2)
+	})
 }

--- a/pkg/client/accounting.go
+++ b/pkg/client/accounting.go
@@ -69,9 +69,7 @@ func (c Client) getBalanceV2(ctx context.Context, owner *owner.ID, opts ...CallO
 			return nil, errors.Wrap(err, "can't verify response message")
 		}
 
-		return &accounting.Decimal{
-			Decimal: *resp.GetBody().GetBalance(),
-		}, nil
+		return accounting.NewDecimalFromV2(resp.GetBody().GetBalance()), nil
 	default:
 		return nil, unsupportedProtocolErr
 	}

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -27,7 +27,7 @@ func TestExample(t *testing.T) {
 	resp, err := cli.GetSelfBalance(context.Background())
 	require.NoError(t, err)
 
-	fmt.Println(resp.GetValue(), resp.GetPrecision())
+	fmt.Println(resp.Value(), resp.Precision())
 
 	// create client from grpc connection
 	conn, err := grpc.DialContext(context.Background(), target, grpc.WithBlock(), grpc.WithInsecure())

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -111,3 +111,35 @@ func (c *Container) PlacementPolicy() *netmap.PlacementPolicy {
 func (c *Container) SetPlacementPolicy(v *netmap.PlacementPolicy) {
 	c.v2.SetPlacementPolicy(v.ToV2())
 }
+
+// Marshal marshals Container into a protobuf binary form.
+//
+// Buffer is allocated when the argument is empty.
+// Otherwise, the first buffer is used.
+func (c *Container) Marshal(b ...[]byte) ([]byte, error) {
+	var buf []byte
+	if len(b) > 0 {
+		buf = b[0]
+	}
+
+	return c.v2.
+		StableMarshal(buf)
+}
+
+// Unmarshal unmarshals protobuf binary representation of Container.
+func (c *Container) Unmarshal(data []byte) error {
+	return c.v2.
+		Unmarshal(data)
+}
+
+// MarshalJSON encodes Container to protobuf JSON format.
+func (c *Container) MarshalJSON() ([]byte, error) {
+	return c.v2.
+		MarshalJSON()
+}
+
+// UnmarshalJSON decodes Container from protobuf JSON format.
+func (c *Container) UnmarshalJSON(data []byte) error {
+	return c.v2.
+		UnmarshalJSON(data)
+}

--- a/pkg/container/container_test.go
+++ b/pkg/container/container_test.go
@@ -66,3 +66,29 @@ func generatePlacementPolicy() *netmap.PlacementPolicy {
 
 	return p
 }
+
+func TestContainerEncoding(t *testing.T) {
+	c := container.New(
+		container.WithAttribute("key", "value"),
+	)
+
+	t.Run("binary", func(t *testing.T) {
+		data, err := c.Marshal()
+		require.NoError(t, err)
+
+		c2 := container.New()
+		require.NoError(t, c2.Unmarshal(data))
+
+		require.Equal(t, c, c2)
+	})
+
+	t.Run("json", func(t *testing.T) {
+		data, err := c.MarshalJSON()
+		require.NoError(t, err)
+
+		c2 := container.New()
+		require.NoError(t, c2.UnmarshalJSON(data))
+
+		require.Equal(t, c, c2)
+	})
+}

--- a/pkg/container/id.go
+++ b/pkg/container/id.go
@@ -65,3 +65,35 @@ func (id *ID) Parse(s string) error {
 func (id *ID) String() string {
 	return base58.Encode((*refs.ContainerID)(id).GetValue())
 }
+
+// Marshal marshals ID into a protobuf binary form.
+//
+// Buffer is allocated when the argument is empty.
+// Otherwise, the first buffer is used.
+func (id *ID) Marshal(b ...[]byte) ([]byte, error) {
+	var buf []byte
+	if len(b) > 0 {
+		buf = b[0]
+	}
+
+	return (*refs.ContainerID)(id).
+		StableMarshal(buf)
+}
+
+// Unmarshal unmarshals protobuf binary representation of ID.
+func (id *ID) Unmarshal(data []byte) error {
+	return (*refs.ContainerID)(id).
+		Unmarshal(data)
+}
+
+// MarshalJSON encodes ID to protobuf JSON format.
+func (id *ID) MarshalJSON() ([]byte, error) {
+	return (*refs.ContainerID)(id).
+		MarshalJSON()
+}
+
+// UnmarshalJSON decodes ID from protobuf JSON format.
+func (id *ID) UnmarshalJSON(data []byte) error {
+	return (*refs.ContainerID)(id).
+		UnmarshalJSON(data)
+}

--- a/pkg/container/id_test.go
+++ b/pkg/container/id_test.go
@@ -90,3 +90,28 @@ func TestID_String(t *testing.T) {
 		}
 	})
 }
+
+func TestContainerIDEncoding(t *testing.T) {
+	id := NewID()
+	id.SetSHA256(randSHA256Checksum(t))
+
+	t.Run("binary", func(t *testing.T) {
+		data, err := id.Marshal()
+		require.NoError(t, err)
+
+		id2 := NewID()
+		require.NoError(t, id2.Unmarshal(data))
+
+		require.Equal(t, id, id2)
+	})
+
+	t.Run("json", func(t *testing.T) {
+		data, err := id.MarshalJSON()
+		require.NoError(t, err)
+
+		a2 := NewID()
+		require.NoError(t, a2.UnmarshalJSON(data))
+
+		require.Equal(t, id, a2)
+	})
+}

--- a/pkg/netmap/filter.go
+++ b/pkg/netmap/filter.go
@@ -229,3 +229,34 @@ func (f *Filter) SetInnerFilters(fs ...*Filter) {
 	(*netmap.Filter)(f).
 		SetFilters(filtersToV2(fs))
 }
+
+// Marshal marshals Filter into a protobuf binary form.
+//
+// Buffer is allocated when the argument is empty.
+// Otherwise, the first buffer is used.
+func (f *Filter) Marshal(b ...[]byte) ([]byte, error) {
+	var buf []byte
+	if len(b) > 0 {
+		buf = b[0]
+	}
+
+	return (*netmap.Filter)(f).StableMarshal(buf)
+}
+
+// Unmarshal unmarshals protobuf binary representation of Filter.
+func (f *Filter) Unmarshal(data []byte) error {
+	return (*netmap.Filter)(f).
+		Unmarshal(data)
+}
+
+// MarshalJSON encodes Filter to protobuf JSON format.
+func (f *Filter) MarshalJSON() ([]byte, error) {
+	return (*netmap.Filter)(f).
+		MarshalJSON()
+}
+
+// UnmarshalJSON decodes Filter from protobuf JSON format.
+func (f *Filter) UnmarshalJSON(data []byte) error {
+	return (*netmap.Filter)(f).
+		UnmarshalJSON(data)
+}

--- a/pkg/netmap/filter_test.go
+++ b/pkg/netmap/filter_test.go
@@ -269,3 +269,29 @@ func TestFilter_InnerFilters(t *testing.T) {
 
 	require.Equal(t, []*Filter{f1, f2}, f.InnerFilters())
 }
+
+func TestFilterEncoding(t *testing.T) {
+	f := newFilter("name", "key", "value", OpEQ,
+		newFilter("name2", "key2", "value", OpOR),
+	)
+
+	t.Run("binary", func(t *testing.T) {
+		data, err := f.Marshal()
+		require.NoError(t, err)
+
+		f2 := NewFilter()
+		require.NoError(t, f2.Unmarshal(data))
+
+		require.Equal(t, f, f2)
+	})
+
+	t.Run("json", func(t *testing.T) {
+		data, err := f.MarshalJSON()
+		require.NoError(t, err)
+
+		f2 := NewFilter()
+		require.NoError(t, f2.UnmarshalJSON(data))
+
+		require.Equal(t, f, f2)
+	})
+}

--- a/pkg/netmap/node_info.go
+++ b/pkg/netmap/node_info.go
@@ -193,6 +193,38 @@ func (a *NodeAttribute) SetParentKeys(keys ...string) {
 		SetParents(keys)
 }
 
+// Marshal marshals NodeAttribute into a protobuf binary form.
+//
+// Buffer is allocated when the argument is empty.
+// Otherwise, the first buffer is used.
+func (a *NodeAttribute) Marshal(b ...[]byte) ([]byte, error) {
+	var buf []byte
+	if len(b) > 0 {
+		buf = b[0]
+	}
+
+	return (*netmap.Attribute)(a).
+		StableMarshal(buf)
+}
+
+// Unmarshal unmarshals protobuf binary representation of NodeAttribute.
+func (a *NodeAttribute) Unmarshal(data []byte) error {
+	return (*netmap.Attribute)(a).
+		Unmarshal(data)
+}
+
+// MarshalJSON encodes NodeAttribute to protobuf JSON format.
+func (a *NodeAttribute) MarshalJSON() ([]byte, error) {
+	return (*netmap.Attribute)(a).
+		MarshalJSON()
+}
+
+// UnmarshalJSON decodes NodeAttribute from protobuf JSON format.
+func (a *NodeAttribute) UnmarshalJSON(data []byte) error {
+	return (*netmap.Attribute)(a).
+		UnmarshalJSON(data)
+}
+
 // NewNodeInfo creates and returns new NodeInfo instance.
 func NewNodeInfo() *NodeInfo {
 	return NewNodeInfoFromV2(new(netmap.NodeInfo))
@@ -201,21 +233,6 @@ func NewNodeInfo() *NodeInfo {
 // NewNodeInfoFromV2 converts v2 NodeInfo to NodeInfo.
 func NewNodeInfoFromV2(i *netmap.NodeInfo) *NodeInfo {
 	return (*NodeInfo)(i)
-}
-
-// NodeInfoToJSON encodes NodeInfo to JSON format.
-func NodeInfoToJSON(i *NodeInfo) ([]byte, error) {
-	return netmap.NodeInfoToJSON(i.ToV2())
-}
-
-// NodeInfoFromJSON decodes NodeInfo from JSON-encoded data.
-func NodeInfoFromJSON(data []byte) (*NodeInfo, error) {
-	i, err := netmap.NodeInfoFromJSON(data)
-	if err != nil {
-		return nil, err
-	}
-
-	return NewNodeInfoFromV2(i), nil
 }
 
 // ToV2 converts NodeInfo to v2 NodeInfo.
@@ -285,4 +302,36 @@ func (i *NodeInfo) State() NodeState {
 func (i *NodeInfo) SetState(s NodeState) {
 	(*netmap.NodeInfo)(i).
 		SetState(s.ToV2())
+}
+
+// Marshal marshals NodeInfo into a protobuf binary form.
+//
+// Buffer is allocated when the argument is empty.
+// Otherwise, the first buffer is used.
+func (i *NodeInfo) Marshal(b ...[]byte) ([]byte, error) {
+	var buf []byte
+	if len(b) > 0 {
+		buf = b[0]
+	}
+
+	return (*netmap.NodeInfo)(i).
+		StableMarshal(buf)
+}
+
+// Unmarshal unmarshals protobuf binary representation of NodeInfo.
+func (i *NodeInfo) Unmarshal(data []byte) error {
+	return (*netmap.NodeInfo)(i).
+		Unmarshal(data)
+}
+
+// MarshalJSON encodes NodeInfo to protobuf JSON format.
+func (i *NodeInfo) MarshalJSON() ([]byte, error) {
+	return (*netmap.NodeInfo)(i).
+		MarshalJSON()
+}
+
+// UnmarshalJSON decodes NodeInfo from protobuf JSON format.
+func (i *NodeInfo) UnmarshalJSON(data []byte) error {
+	return (*netmap.NodeInfo)(i).
+		UnmarshalJSON(data)
 }

--- a/pkg/netmap/node_info_test.go
+++ b/pkg/netmap/node_info_test.go
@@ -128,18 +128,54 @@ func TestNodeInfo_Attributes(t *testing.T) {
 	require.Equal(t, as, i.Attributes())
 }
 
-func TestNodeInfoJSON(t *testing.T) {
+func TestNodeAttributeEncoding(t *testing.T) {
+	a := testNodeAttribute()
+
+	t.Run("binary", func(t *testing.T) {
+		data, err := a.Marshal()
+		require.NoError(t, err)
+
+		a2 := NewNodeAttribute()
+		require.NoError(t, a2.Unmarshal(data))
+
+		require.Equal(t, a, a2)
+	})
+
+	t.Run("json", func(t *testing.T) {
+		data, err := a.MarshalJSON()
+		require.NoError(t, err)
+
+		a2 := NewNodeAttribute()
+		require.NoError(t, a2.UnmarshalJSON(data))
+
+		require.Equal(t, a, a2)
+	})
+}
+
+func TestNodeInfoEncoding(t *testing.T) {
 	i := NewNodeInfo()
 	i.SetPublicKey([]byte{1, 2, 3})
-	i.SetAddress("some node address")
+	i.SetAddress("192.168.0.1")
 	i.SetState(NodeStateOnline)
-	i.SetAttributes(testNodeAttribute(), testNodeAttribute())
+	i.SetAttributes(testNodeAttribute())
 
-	j, err := NodeInfoToJSON(i)
-	require.NoError(t, err)
+	t.Run("binary", func(t *testing.T) {
+		data, err := i.Marshal()
+		require.NoError(t, err)
 
-	i2, err := NodeInfoFromJSON(j)
-	require.NoError(t, err)
+		i2 := NewNodeInfo()
+		require.NoError(t, i2.Unmarshal(data))
 
-	require.Equal(t, i, i2)
+		require.Equal(t, i, i2)
+	})
+
+	t.Run("json", func(t *testing.T) {
+		data, err := i.MarshalJSON()
+		require.NoError(t, err)
+
+		i2 := NewNodeInfo()
+		require.NoError(t, i2.UnmarshalJSON(data))
+
+		require.Equal(t, i, i2)
+	})
 }

--- a/pkg/netmap/policy.go
+++ b/pkg/netmap/policy.go
@@ -7,21 +7,6 @@ import (
 // PlacementPolicy represents v2-compatible placement policy.
 type PlacementPolicy netmap.PlacementPolicy
 
-// PlacementPolicyToJSON encodes PlacementPolicy to JSON format.
-func PlacementPolicyToJSON(p *PlacementPolicy) ([]byte, error) {
-	return netmap.PlacementPolicyToJSON(p.ToV2())
-}
-
-// PlacementPolicyFromJSON decodes PlacementPolicy from JSON format.
-func PlacementPolicyFromJSON(data []byte) (*PlacementPolicy, error) {
-	p, err := netmap.PlacementPolicyFromJSON(data)
-	if err != nil {
-		return nil, err
-	}
-
-	return NewPlacementPolicyFromV2(p), nil
-}
-
 // NewPlacementPolicy creates and returns new PlacementPolicy instance.
 func NewPlacementPolicy() *PlacementPolicy {
 	return NewPlacementPolicyFromV2(new(netmap.PlacementPolicy))
@@ -113,4 +98,36 @@ func (p *PlacementPolicy) Filters() []*Filter {
 func (p *PlacementPolicy) SetFilters(fs ...*Filter) {
 	(*netmap.PlacementPolicy)(p).
 		SetFilters(filtersToV2(fs))
+}
+
+// Marshal marshals PlacementPolicy into a protobuf binary form.
+//
+// Buffer is allocated when the argument is empty.
+// Otherwise, the first buffer is used.
+func (p *PlacementPolicy) Marshal(b ...[]byte) ([]byte, error) {
+	var buf []byte
+	if len(b) > 0 {
+		buf = b[0]
+	}
+
+	return (*netmap.PlacementPolicy)(p).
+		StableMarshal(buf)
+}
+
+// Unmarshal unmarshals protobuf binary representation of PlacementPolicy.
+func (p *PlacementPolicy) Unmarshal(data []byte) error {
+	return (*netmap.PlacementPolicy)(p).
+		Unmarshal(data)
+}
+
+// MarshalJSON encodes PlacementPolicy to protobuf JSON format.
+func (p *PlacementPolicy) MarshalJSON() ([]byte, error) {
+	return (*netmap.PlacementPolicy)(p).
+		MarshalJSON()
+}
+
+// UnmarshalJSON decodes PlacementPolicy from protobuf JSON format.
+func (p *PlacementPolicy) UnmarshalJSON(data []byte) error {
+	return (*netmap.PlacementPolicy)(p).
+		UnmarshalJSON(data)
 }

--- a/pkg/netmap/policy_test.go
+++ b/pkg/netmap/policy_test.go
@@ -67,3 +67,27 @@ func TestPlacementPolicy_Filters(t *testing.T) {
 
 	require.Equal(t, fs, p.Filters())
 }
+
+func TestPlacementPolicyEncoding(t *testing.T) {
+	p := newPlacementPolicy(3, nil, nil, nil)
+
+	t.Run("binary", func(t *testing.T) {
+		data, err := p.Marshal()
+		require.NoError(t, err)
+
+		p2 := NewPlacementPolicy()
+		require.NoError(t, p2.Unmarshal(data))
+
+		require.Equal(t, p, p2)
+	})
+
+	t.Run("json", func(t *testing.T) {
+		data, err := p.MarshalJSON()
+		require.NoError(t, err)
+
+		p2 := NewPlacementPolicy()
+		require.NoError(t, p2.UnmarshalJSON(data))
+
+		require.Equal(t, p, p2)
+	})
+}

--- a/pkg/netmap/replica.go
+++ b/pkg/netmap/replica.go
@@ -45,3 +45,35 @@ func (r *Replica) SetSelector(s string) {
 	(*netmap.Replica)(r).
 		SetSelector(s)
 }
+
+// Marshal marshals Replica into a protobuf binary form.
+//
+// Buffer is allocated when the argument is empty.
+// Otherwise, the first buffer is used.
+func (r *Replica) Marshal(b ...[]byte) ([]byte, error) {
+	var buf []byte
+	if len(b) > 0 {
+		buf = b[0]
+	}
+
+	return (*netmap.Replica)(r).
+		StableMarshal(buf)
+}
+
+// Unmarshal unmarshals protobuf binary representation of Replica.
+func (r *Replica) Unmarshal(data []byte) error {
+	return (*netmap.Replica)(r).
+		Unmarshal(data)
+}
+
+// MarshalJSON encodes Replica to protobuf JSON format.
+func (r *Replica) MarshalJSON() ([]byte, error) {
+	return (*netmap.Replica)(r).
+		MarshalJSON()
+}
+
+// UnmarshalJSON decodes Replica from protobuf JSON format.
+func (r *Replica) UnmarshalJSON(data []byte) error {
+	return (*netmap.Replica)(r).
+		UnmarshalJSON(data)
+}

--- a/pkg/netmap/replica_test.go
+++ b/pkg/netmap/replica_test.go
@@ -42,3 +42,27 @@ func TestReplica_Selector(t *testing.T) {
 
 	require.Equal(t, s, r.Selector())
 }
+
+func TestReplicaEncoding(t *testing.T) {
+	r := newReplica(3, "selector")
+
+	t.Run("binary", func(t *testing.T) {
+		data, err := r.Marshal()
+		require.NoError(t, err)
+
+		r2 := NewReplica()
+		require.NoError(t, r2.Unmarshal(data))
+
+		require.Equal(t, r, r2)
+	})
+
+	t.Run("json", func(t *testing.T) {
+		data, err := r.MarshalJSON()
+		require.NoError(t, err)
+
+		r2 := NewReplica()
+		require.NoError(t, r2.UnmarshalJSON(data))
+
+		require.Equal(t, r, r2)
+	})
+}

--- a/pkg/netmap/selector.go
+++ b/pkg/netmap/selector.go
@@ -198,3 +198,34 @@ func (s *Selector) SetFilter(f string) {
 	(*netmap.Selector)(s).
 		SetFilter(f)
 }
+
+// Marshal marshals Selector into a protobuf binary form.
+//
+// Buffer is allocated when the argument is empty.
+// Otherwise, the first buffer is used.
+func (s *Selector) Marshal(b ...[]byte) ([]byte, error) {
+	var buf []byte
+	if len(b) > 0 {
+		buf = b[0]
+	}
+
+	return (*netmap.Selector)(s).StableMarshal(buf)
+}
+
+// Unmarshal unmarshals protobuf binary representation of Selector.
+func (s *Selector) Unmarshal(data []byte) error {
+	return (*netmap.Selector)(s).
+		Unmarshal(data)
+}
+
+// MarshalJSON encodes Selector to protobuf JSON format.
+func (s *Selector) MarshalJSON() ([]byte, error) {
+	return (*netmap.Selector)(s).
+		MarshalJSON()
+}
+
+// UnmarshalJSON decodes Selector from protobuf JSON format.
+func (s *Selector) UnmarshalJSON(data []byte) error {
+	return (*netmap.Selector)(s).
+		UnmarshalJSON(data)
+}

--- a/pkg/netmap/selector_test.go
+++ b/pkg/netmap/selector_test.go
@@ -307,3 +307,27 @@ func TestSelector_Filter(t *testing.T) {
 
 	require.Equal(t, f, s.Filter())
 }
+
+func TestSelectorEncoding(t *testing.T) {
+	s := newSelector("name", "atte", ClauseSame, 1, "filter")
+
+	t.Run("binary", func(t *testing.T) {
+		data, err := s.Marshal()
+		require.NoError(t, err)
+
+		s2 := NewSelector()
+		require.NoError(t, s2.Unmarshal(data))
+
+		require.Equal(t, s, s2)
+	})
+
+	t.Run("json", func(t *testing.T) {
+		data, err := s.MarshalJSON()
+		require.NoError(t, err)
+
+		s2 := NewSelector()
+		require.NoError(t, s2.UnmarshalJSON(data))
+
+		require.Equal(t, s, s2)
+	})
+}

--- a/pkg/object/address.go
+++ b/pkg/object/address.go
@@ -6,7 +6,6 @@ import (
 	"github.com/nspcc-dev/neofs-api-go/internal"
 	"github.com/nspcc-dev/neofs-api-go/pkg/container"
 	"github.com/nspcc-dev/neofs-api-go/v2/refs"
-	"github.com/pkg/errors"
 )
 
 // Address represents v2-compatible object address.
@@ -36,16 +35,6 @@ func NewAddress() *Address {
 // ToV2 converts Address to v2 Address message.
 func (a *Address) ToV2() *refs.Address {
 	return (*refs.Address)(a)
-}
-
-// AddressFromBytes restores Address from a binary representation.
-func AddressFromBytes(data []byte) (*Address, error) {
-	addrV2 := new(refs.Address)
-	if err := addrV2.StableUnmarshal(data); err != nil {
-		return nil, errors.Wrap(err, "could not unmarshal object address")
-	}
-
-	return NewAddressFromV2(addrV2), nil
 }
 
 // GetContainerID returns container identifier.
@@ -101,4 +90,36 @@ func (a *Address) String() string {
 		a.GetContainerID().String(),
 		a.GetObjectID().String(),
 	}, addressSeparator)
+}
+
+// Marshal marshals Address into a protobuf binary form.
+//
+// Buffer is allocated when the argument is empty.
+// Otherwise, the first buffer is used.
+func (a *Address) Marshal(b ...[]byte) ([]byte, error) {
+	var buf []byte
+	if len(b) > 0 {
+		buf = b[0]
+	}
+
+	return (*refs.Address)(a).
+		StableMarshal(buf)
+}
+
+// Unmarshal unmarshals protobuf binary representation of Address.
+func (a *Address) Unmarshal(data []byte) error {
+	return (*refs.Address)(a).
+		Unmarshal(data)
+}
+
+// MarshalJSON encodes Address to protobuf JSON format.
+func (a *Address) MarshalJSON() ([]byte, error) {
+	return (*refs.Address)(a).
+		MarshalJSON()
+}
+
+// UnmarshalJSON decodes Address from protobuf JSON format.
+func (a *Address) UnmarshalJSON(data []byte) error {
+	return (*refs.Address)(a).
+		UnmarshalJSON(data)
 }

--- a/pkg/object/address_test.go
+++ b/pkg/object/address_test.go
@@ -60,3 +60,29 @@ func TestAddress_Parse(t *testing.T) {
 		require.EqualError(t, NewAddress().Parse(s), ErrBadID.Error())
 	})
 }
+
+func TestAddressEncoding(t *testing.T) {
+	a := NewAddress()
+	a.SetObjectID(randID(t))
+	a.SetContainerID(randCID(t))
+
+	t.Run("binary", func(t *testing.T) {
+		data, err := a.Marshal()
+		require.NoError(t, err)
+
+		a2 := NewAddress()
+		require.NoError(t, a2.Unmarshal(data))
+
+		require.Equal(t, a, a2)
+	})
+
+	t.Run("json", func(t *testing.T) {
+		data, err := a.MarshalJSON()
+		require.NoError(t, err)
+
+		a2 := NewAddress()
+		require.NoError(t, a2.UnmarshalJSON(data))
+
+		require.Equal(t, a, a2)
+	})
+}

--- a/pkg/object/attribute.go
+++ b/pkg/object/attribute.go
@@ -43,3 +43,35 @@ func (a *Attribute) SetValue(v string) {
 func (a *Attribute) ToV2() *object.Attribute {
 	return (*object.Attribute)(a)
 }
+
+// Marshal marshals Attribute into a protobuf binary form.
+//
+// Buffer is allocated when the argument is empty.
+// Otherwise, the first buffer is used.
+func (d *Attribute) Marshal(b ...[]byte) ([]byte, error) {
+	var buf []byte
+	if len(b) > 0 {
+		buf = b[0]
+	}
+
+	return (*object.Attribute)(d).
+		StableMarshal(buf)
+}
+
+// Unmarshal unmarshals protobuf binary representation of Attribute.
+func (d *Attribute) Unmarshal(data []byte) error {
+	return (*object.Attribute)(d).
+		Unmarshal(data)
+}
+
+// MarshalJSON encodes Attribute to protobuf JSON format.
+func (d *Attribute) MarshalJSON() ([]byte, error) {
+	return (*object.Attribute)(d).
+		MarshalJSON()
+}
+
+// UnmarshalJSON decodes Attribute from protobuf JSON format.
+func (d *Attribute) UnmarshalJSON(data []byte) error {
+	return (*object.Attribute)(d).
+		UnmarshalJSON(data)
+}

--- a/pkg/object/attribute.go
+++ b/pkg/object/attribute.go
@@ -48,30 +48,30 @@ func (a *Attribute) ToV2() *object.Attribute {
 //
 // Buffer is allocated when the argument is empty.
 // Otherwise, the first buffer is used.
-func (d *Attribute) Marshal(b ...[]byte) ([]byte, error) {
+func (a *Attribute) Marshal(b ...[]byte) ([]byte, error) {
 	var buf []byte
 	if len(b) > 0 {
 		buf = b[0]
 	}
 
-	return (*object.Attribute)(d).
+	return (*object.Attribute)(a).
 		StableMarshal(buf)
 }
 
 // Unmarshal unmarshals protobuf binary representation of Attribute.
-func (d *Attribute) Unmarshal(data []byte) error {
-	return (*object.Attribute)(d).
+func (a *Attribute) Unmarshal(data []byte) error {
+	return (*object.Attribute)(a).
 		Unmarshal(data)
 }
 
 // MarshalJSON encodes Attribute to protobuf JSON format.
-func (d *Attribute) MarshalJSON() ([]byte, error) {
-	return (*object.Attribute)(d).
+func (a *Attribute) MarshalJSON() ([]byte, error) {
+	return (*object.Attribute)(a).
 		MarshalJSON()
 }
 
 // UnmarshalJSON decodes Attribute from protobuf JSON format.
-func (d *Attribute) UnmarshalJSON(data []byte) error {
-	return (*object.Attribute)(d).
+func (a *Attribute) UnmarshalJSON(data []byte) error {
+	return (*object.Attribute)(a).
 		UnmarshalJSON(data)
 }

--- a/pkg/object/attribute_test.go
+++ b/pkg/object/attribute_test.go
@@ -21,3 +21,29 @@ func TestAttribute(t *testing.T) {
 	require.Equal(t, key, aV2.GetKey())
 	require.Equal(t, val, aV2.GetValue())
 }
+
+func TestAttributeEncoding(t *testing.T) {
+	a := NewAttribute()
+	a.SetKey("key")
+	a.SetValue("value")
+
+	t.Run("binary", func(t *testing.T) {
+		data, err := a.Marshal()
+		require.NoError(t, err)
+
+		a2 := NewAttribute()
+		require.NoError(t, a2.Unmarshal(data))
+
+		require.Equal(t, a, a2)
+	})
+
+	t.Run("json", func(t *testing.T) {
+		data, err := a.MarshalJSON()
+		require.NoError(t, err)
+
+		a2 := NewAttribute()
+		require.NoError(t, a2.UnmarshalJSON(data))
+
+		require.Equal(t, a, a2)
+	})
+}

--- a/pkg/object/id.go
+++ b/pkg/object/id.go
@@ -65,3 +65,35 @@ func (id *ID) Parse(s string) error {
 func (id *ID) String() string {
 	return base58.Encode((*refs.ObjectID)(id).GetValue())
 }
+
+// Marshal marshals ID into a protobuf binary form.
+//
+// Buffer is allocated when the argument is empty.
+// Otherwise, the first buffer is used.
+func (id *ID) Marshal(b ...[]byte) ([]byte, error) {
+	var buf []byte
+	if len(b) > 0 {
+		buf = b[0]
+	}
+
+	return (*refs.ObjectID)(id).
+		StableMarshal(buf)
+}
+
+// Unmarshal unmarshals protobuf binary representation of ID.
+func (id *ID) Unmarshal(data []byte) error {
+	return (*refs.ObjectID)(id).
+		Unmarshal(data)
+}
+
+// MarshalJSON encodes ID to protobuf JSON format.
+func (id *ID) MarshalJSON() ([]byte, error) {
+	return (*refs.ObjectID)(id).
+		MarshalJSON()
+}
+
+// UnmarshalJSON decodes ID from protobuf JSON format.
+func (id *ID) UnmarshalJSON(data []byte) error {
+	return (*refs.ObjectID)(id).
+		UnmarshalJSON(data)
+}

--- a/pkg/object/id_test.go
+++ b/pkg/object/id_test.go
@@ -83,3 +83,27 @@ func TestID_String(t *testing.T) {
 		}
 	})
 }
+
+func TestObjectIDEncoding(t *testing.T) {
+	id := randID(t)
+
+	t.Run("binary", func(t *testing.T) {
+		data, err := id.Marshal()
+		require.NoError(t, err)
+
+		id2 := NewID()
+		require.NoError(t, id2.Unmarshal(data))
+
+		require.Equal(t, id, id2)
+	})
+
+	t.Run("json", func(t *testing.T) {
+		data, err := id.MarshalJSON()
+		require.NoError(t, err)
+
+		a2 := NewID()
+		require.NoError(t, a2.UnmarshalJSON(data))
+
+		require.Equal(t, id, a2)
+	})
+}

--- a/pkg/object/object.go
+++ b/pkg/object/object.go
@@ -37,14 +37,3 @@ func (o *Object) ToV2() *object.Object {
 
 	return nil
 }
-
-// FromBytes restores Object instance from a binary representation.
-func FromBytes(data []byte) (*Object, error) {
-	oV2 := new(object.Object)
-
-	if err := oV2.StableUnmarshal(data); err != nil {
-		return nil, err
-	}
-
-	return NewFromV2(oV2), nil
-}

--- a/pkg/object/raw_test.go
+++ b/pkg/object/raw_test.go
@@ -20,6 +20,13 @@ func randID(t *testing.T) *ID {
 	return id
 }
 
+func randCID(t *testing.T) *container.ID {
+	id := container.NewID()
+	id.SetSHA256(randSHA256Checksum(t))
+
+	return id
+}
+
 func randSHA256Checksum(t *testing.T) (cs [sha256.Size]byte) {
 	_, err := rand.Read(cs[:])
 	require.NoError(t, err)

--- a/pkg/object/raw_test.go
+++ b/pkg/object/raw_test.go
@@ -287,3 +287,28 @@ func TestRwObject_HasParent(t *testing.T) {
 
 	require.False(t, obj.HasParent())
 }
+
+func TestRWObjectEncoding(t *testing.T) {
+	o := NewRaw()
+	o.SetID(randID(t))
+
+	t.Run("binary", func(t *testing.T) {
+		data, err := o.Marshal()
+		require.NoError(t, err)
+
+		o2 := NewRaw()
+		require.NoError(t, o2.Unmarshal(data))
+
+		require.Equal(t, o, o2)
+	})
+
+	t.Run("json", func(t *testing.T) {
+		data, err := o.MarshalJSON()
+		require.NoError(t, err)
+
+		o2 := NewRaw()
+		require.NoError(t, o2.UnmarshalJSON(data))
+
+		require.Equal(t, o, o2)
+	})
+}

--- a/pkg/object/rw.go
+++ b/pkg/object/rw.go
@@ -352,3 +352,35 @@ func (o *rwObject) HasParent() bool {
 		GetHeader().
 		GetSplit() != nil
 }
+
+// Marshal marshals object into a protobuf binary form.
+//
+// Buffer is allocated when the argument is empty.
+// Otherwise, the first buffer is used.
+func (o *rwObject) Marshal(b ...[]byte) ([]byte, error) {
+	var buf []byte
+	if len(b) > 0 {
+		buf = b[0]
+	}
+
+	return (*object.Object)(o).
+		StableMarshal(buf)
+}
+
+// Unmarshal unmarshals protobuf binary representation of object.
+func (o *rwObject) Unmarshal(data []byte) error {
+	return (*object.Object)(o).
+		Unmarshal(data)
+}
+
+// MarshalJSON encodes object to protobuf JSON format.
+func (o *rwObject) MarshalJSON() ([]byte, error) {
+	return (*object.Object)(o).
+		MarshalJSON()
+}
+
+// UnmarshalJSON decodes object from protobuf JSON format.
+func (o *rwObject) UnmarshalJSON(data []byte) error {
+	return (*object.Object)(o).
+		UnmarshalJSON(data)
+}

--- a/pkg/owner/id.go
+++ b/pkg/owner/id.go
@@ -71,3 +71,35 @@ func (id *ID) Parse(s string) error {
 
 	return nil
 }
+
+// Marshal marshals ID into a protobuf binary form.
+//
+// Buffer is allocated when the argument is empty.
+// Otherwise, the first buffer is used.
+func (id *ID) Marshal(b ...[]byte) ([]byte, error) {
+	var buf []byte
+	if len(b) > 0 {
+		buf = b[0]
+	}
+
+	return (*refs.OwnerID)(id).
+		StableMarshal(buf)
+}
+
+// Unmarshal unmarshals protobuf binary representation of ID.
+func (id *ID) Unmarshal(data []byte) error {
+	return (*refs.OwnerID)(id).
+		Unmarshal(data)
+}
+
+// MarshalJSON encodes ID to protobuf JSON format.
+func (id *ID) MarshalJSON() ([]byte, error) {
+	return (*refs.OwnerID)(id).
+		MarshalJSON()
+}
+
+// UnmarshalJSON decodes ID from protobuf JSON format.
+func (id *ID) UnmarshalJSON(data []byte) error {
+	return (*refs.OwnerID)(id).
+		UnmarshalJSON(data)
+}

--- a/pkg/owner/id_test.go
+++ b/pkg/owner/id_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestIDV2(t *testing.T) {
+func randID(t *testing.T) *ID {
 	id := NewID()
 
 	wallet := new(NEO3Wallet)
@@ -20,9 +20,15 @@ func TestIDV2(t *testing.T) {
 
 	id.SetNeo3Wallet(wallet)
 
+	return id
+}
+
+func TestIDV2(t *testing.T) {
+	id := randID(t)
+
 	idV2 := id.ToV2()
 
-	require.Equal(t, wallet.Bytes(), idV2.GetValue())
+	require.Equal(t, id, NewIDFromV2(idV2))
 }
 
 func TestNewIDFromNeo3Wallet(t *testing.T) {
@@ -61,5 +67,29 @@ func TestID_Parse(t *testing.T) {
 				require.EqualError(t, cid.Parse(str), ErrBadID.Error())
 			})
 		}
+	})
+}
+
+func TestIDEncoding(t *testing.T) {
+	id := randID(t)
+
+	t.Run("binary", func(t *testing.T) {
+		data, err := id.Marshal()
+		require.NoError(t, err)
+
+		id2 := NewID()
+		require.NoError(t, id2.Unmarshal(data))
+
+		require.Equal(t, id, id2)
+	})
+
+	t.Run("json", func(t *testing.T) {
+		data, err := id.MarshalJSON()
+		require.NoError(t, err)
+
+		a2 := NewID()
+		require.NoError(t, a2.UnmarshalJSON(data))
+
+		require.Equal(t, id, a2)
 	})
 }

--- a/pkg/signature.go
+++ b/pkg/signature.go
@@ -42,3 +42,35 @@ func (s *Signature) SetSign(v []byte) {
 func (s *Signature) ToV2() *refs.Signature {
 	return (*refs.Signature)(s)
 }
+
+// Marshal marshals Signature into a protobuf binary form.
+//
+// Buffer is allocated when the argument is empty.
+// Otherwise, the first buffer is used.
+func (s *Signature) Marshal(b ...[]byte) ([]byte, error) {
+	var buf []byte
+	if len(b) > 0 {
+		buf = b[0]
+	}
+
+	return (*refs.Signature)(s).
+		StableMarshal(buf)
+}
+
+// Unmarshal unmarshals protobuf binary representation of Signature.
+func (s *Signature) Unmarshal(data []byte) error {
+	return (*refs.Signature)(s).
+		Unmarshal(data)
+}
+
+// MarshalJSON encodes Signature to protobuf JSON format.
+func (s *Signature) MarshalJSON() ([]byte, error) {
+	return (*refs.Signature)(s).
+		MarshalJSON()
+}
+
+// UnmarshalJSON decodes Signature from protobuf JSON format.
+func (s *Signature) UnmarshalJSON(data []byte) error {
+	return (*refs.Signature)(s).
+		UnmarshalJSON(data)
+}

--- a/pkg/signature_test.go
+++ b/pkg/signature_test.go
@@ -1,0 +1,33 @@
+package pkg
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSignatureEncoding(t *testing.T) {
+	s := NewSignature()
+	s.SetKey([]byte("key"))
+	s.SetSign([]byte("sign"))
+
+	t.Run("binary", func(t *testing.T) {
+		data, err := s.Marshal()
+		require.NoError(t, err)
+
+		s2 := NewSignature()
+		require.NoError(t, s2.Unmarshal(data))
+
+		require.Equal(t, s, s2)
+	})
+
+	t.Run("json", func(t *testing.T) {
+		data, err := s.MarshalJSON()
+		require.NoError(t, err)
+
+		s2 := NewSignature()
+		require.NoError(t, s2.UnmarshalJSON(data))
+
+		require.Equal(t, s, s2)
+	})
+}

--- a/pkg/token/bearer.go
+++ b/pkg/token/bearer.go
@@ -118,3 +118,47 @@ func sanityCheck(b *BearerToken) error {
 
 	return nil
 }
+
+// Marshal marshals BearerToken into a protobuf binary form.
+//
+// Buffer is allocated when the argument is empty.
+// Otherwise, the first buffer is used.
+func (b *BearerToken) Marshal(bs ...[]byte) ([]byte, error) {
+	var buf []byte
+	if len(bs) > 0 {
+		buf = bs[0]
+	}
+
+	return b.ToV2().
+		StableMarshal(buf)
+}
+
+// Unmarshal unmarshals protobuf binary representation of BearerToken.
+func (b *BearerToken) Unmarshal(data []byte) error {
+	fV2 := new(acl.BearerToken)
+	if err := fV2.Unmarshal(data); err != nil {
+		return err
+	}
+
+	*b = *NewBearerTokenFromV2(fV2)
+
+	return nil
+}
+
+// MarshalJSON encodes BearerToken to protobuf JSON format.
+func (b *BearerToken) MarshalJSON() ([]byte, error) {
+	return b.ToV2().
+		MarshalJSON()
+}
+
+// UnmarshalJSON decodes BearerToken from protobuf JSON format.
+func (b *BearerToken) UnmarshalJSON(data []byte) error {
+	fV2 := new(acl.BearerToken)
+	if err := fV2.UnmarshalJSON(data); err != nil {
+		return err
+	}
+
+	*b = *NewBearerTokenFromV2(fV2)
+
+	return nil
+}

--- a/pkg/token/bearer_test.go
+++ b/pkg/token/bearer_test.go
@@ -30,3 +30,28 @@ func TestBearerToken_Issuer(t *testing.T) {
 		require.Equal(t, bearerToken.Issuer().String(), ownerID.String())
 	})
 }
+
+func TestFilterEncoding(t *testing.T) {
+	f := token.NewBearerToken()
+	f.SetLifetime(1, 2, 3)
+
+	t.Run("binary", func(t *testing.T) {
+		data, err := f.Marshal()
+		require.NoError(t, err)
+
+		f2 := token.NewBearerToken()
+		require.NoError(t, f2.Unmarshal(data))
+
+		require.Equal(t, f, f2)
+	})
+
+	t.Run("json", func(t *testing.T) {
+		data, err := f.MarshalJSON()
+		require.NoError(t, err)
+
+		d2 := token.NewBearerToken()
+		require.NoError(t, d2.UnmarshalJSON(data))
+
+		require.Equal(t, f, d2)
+	})
+}

--- a/pkg/token/session.go
+++ b/pkg/token/session.go
@@ -76,3 +76,47 @@ func (t *SessionToken) Signature() *pkg.Signature {
 			GetSignature(),
 	)
 }
+
+// Marshal marshals SessionToken into a protobuf binary form.
+//
+// Buffer is allocated when the argument is empty.
+// Otherwise, the first buffer is used.
+func (t *SessionToken) Marshal(bs ...[]byte) ([]byte, error) {
+	var buf []byte
+	if len(bs) > 0 {
+		buf = bs[0]
+	}
+
+	return (*session.SessionToken)(t).
+		StableMarshal(buf)
+}
+
+// Unmarshal unmarshals protobuf binary representation of SessionToken.
+func (t *SessionToken) Unmarshal(data []byte) error {
+	tV2 := new(session.SessionToken)
+	if err := tV2.Unmarshal(data); err != nil {
+		return err
+	}
+
+	*t = *NewSessionTokenFromV2(tV2)
+
+	return nil
+}
+
+// MarshalJSON encodes SessionToken to protobuf JSON format.
+func (t *SessionToken) MarshalJSON() ([]byte, error) {
+	return (*session.SessionToken)(t).
+		MarshalJSON()
+}
+
+// UnmarshalJSON decodes SessionToken from protobuf JSON format.
+func (t *SessionToken) UnmarshalJSON(data []byte) error {
+	tV2 := new(session.SessionToken)
+	if err := tV2.UnmarshalJSON(data); err != nil {
+		return err
+	}
+
+	*t = *NewSessionTokenFromV2(tV2)
+
+	return nil
+}

--- a/pkg/token/session_test.go
+++ b/pkg/token/session_test.go
@@ -40,3 +40,28 @@ func TestSessionToken_SetSessionKey(t *testing.T) {
 
 	require.Equal(t, key, token.SessionKey())
 }
+
+func TestSessionTokenEncoding(t *testing.T) {
+	tok := NewSessionToken()
+	tok.SetID([]byte("id"))
+
+	t.Run("binary", func(t *testing.T) {
+		data, err := tok.Marshal()
+		require.NoError(t, err)
+
+		tok2 := NewSessionToken()
+		require.NoError(t, tok2.Unmarshal(data))
+
+		require.Equal(t, tok, tok2)
+	})
+
+	t.Run("json", func(t *testing.T) {
+		data, err := tok.MarshalJSON()
+		require.NoError(t, err)
+
+		tok2 := NewSessionToken()
+		require.NoError(t, tok2.UnmarshalJSON(data))
+
+		require.Equal(t, tok, tok2)
+	})
+}

--- a/pkg/version.go
+++ b/pkg/version.go
@@ -82,3 +82,35 @@ func IsSupportedVersion(v *Version) error {
 		v.GetMinor(),
 	)
 }
+
+// Marshal marshals Version into a protobuf binary form.
+//
+// Buffer is allocated when the argument is empty.
+// Otherwise, the first buffer is used.
+func (v *Version) Marshal(b ...[]byte) ([]byte, error) {
+	var buf []byte
+	if len(b) > 0 {
+		buf = b[0]
+	}
+
+	return (*refs.Version)(v).
+		StableMarshal(buf)
+}
+
+// Unmarshal unmarshals protobuf binary representation of Version.
+func (v *Version) Unmarshal(data []byte) error {
+	return (*refs.Version)(v).
+		Unmarshal(data)
+}
+
+// MarshalJSON encodes Version to protobuf JSON format.
+func (v *Version) MarshalJSON() ([]byte, error) {
+	return (*refs.Version)(v).
+		MarshalJSON()
+}
+
+// UnmarshalJSON decodes Version from protobuf JSON format.
+func (v *Version) UnmarshalJSON(data []byte) error {
+	return (*refs.Version)(v).
+		UnmarshalJSON(data)
+}

--- a/pkg/version_test.go
+++ b/pkg/version_test.go
@@ -62,3 +62,29 @@ func TestIsSupportedVersion(t *testing.T) {
 		require.Error(t, IsSupportedVersion(v))
 	}
 }
+
+func TestVersionEncoding(t *testing.T) {
+	v := NewVersion()
+	v.SetMajor(1)
+	v.SetMinor(2)
+
+	t.Run("binary", func(t *testing.T) {
+		data, err := v.Marshal()
+		require.NoError(t, err)
+
+		v2 := NewVersion()
+		require.NoError(t, v2.Unmarshal(data))
+
+		require.Equal(t, v, v2)
+	})
+
+	t.Run("json", func(t *testing.T) {
+		data, err := v.MarshalJSON()
+		require.NoError(t, err)
+
+		v2 := NewVersion()
+		require.NoError(t, v2.UnmarshalJSON(data))
+
+		require.Equal(t, v, v2)
+	})
+}

--- a/v2/accounting/json.go
+++ b/v2/accounting/json.go
@@ -1,0 +1,26 @@
+package accounting
+
+import (
+	accounting "github.com/nspcc-dev/neofs-api-go/v2/accounting/grpc"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+func (d *Decimal) MarshalJSON() ([]byte, error) {
+	return protojson.MarshalOptions{
+		EmitUnpopulated: true,
+	}.Marshal(
+		DecimalToGRPCMessage(d),
+	)
+}
+
+func (d *Decimal) UnmarshalJSON(data []byte) error {
+	msg := new(accounting.Decimal)
+
+	if err := protojson.Unmarshal(data, msg); err != nil {
+		return err
+	}
+
+	*d = *DecimalFromGRPCMessage(msg)
+
+	return nil
+}

--- a/v2/accounting/json_test.go
+++ b/v2/accounting/json_test.go
@@ -1,0 +1,20 @@
+package accounting_test
+
+import (
+	"testing"
+
+	"github.com/nspcc-dev/neofs-api-go/v2/accounting"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecimalJSON(t *testing.T) {
+	i := generateDecimal(10)
+
+	data, err := i.MarshalJSON()
+	require.NoError(t, err)
+
+	i2 := new(accounting.Decimal)
+	require.NoError(t, i2.UnmarshalJSON(data))
+
+	require.Equal(t, i, i2)
+}

--- a/v2/accounting/marshal_test.go
+++ b/v2/accounting/marshal_test.go
@@ -10,22 +10,6 @@ import (
 	goproto "google.golang.org/protobuf/proto"
 )
 
-func TestDecimal_StableMarshal(t *testing.T) {
-	decimalFrom := generateDecimal(888)
-	transport := new(grpc.Decimal)
-
-	t.Run("non empty", func(t *testing.T) {
-		wire, err := decimalFrom.StableMarshal(nil)
-		require.NoError(t, err)
-
-		err = goproto.Unmarshal(wire, transport)
-		require.NoError(t, err)
-
-		decimalTo := accounting.DecimalFromGRPCMessage(transport)
-		require.Equal(t, decimalFrom, decimalTo)
-	})
-}
-
 func TestBalanceRequestBody_StableMarshal(t *testing.T) {
 	requestBodyFrom := generateBalanceRequestBody("Owner ID")
 	transport := new(grpc.BalanceRequest_Body)
@@ -81,4 +65,17 @@ func generateBalanceResponseBody(val int64) *accounting.BalanceResponseBody {
 	response.SetBalance(generateDecimal(val))
 
 	return response
+}
+
+func TestDecimalMarshal(t *testing.T) {
+	d := generateDecimal(3)
+
+	data, err := d.StableMarshal(nil)
+	require.NoError(t, err)
+
+	d2 := new(accounting.Decimal)
+
+	require.NoError(t, d2.Unmarshal(data))
+
+	require.Equal(t, d, d2)
 }

--- a/v2/acl/json.go
+++ b/v2/acl/json.go
@@ -102,3 +102,23 @@ func (f *HeaderFilter) UnmarshalJSON(data []byte) error {
 
 	return nil
 }
+
+func (t *Target) MarshalJSON() ([]byte, error) {
+	return protojson.MarshalOptions{
+		EmitUnpopulated: true,
+	}.Marshal(
+		TargetToGRPCMessage(t),
+	)
+}
+
+func (t *Target) UnmarshalJSON(data []byte) error {
+	msg := new(acl.EACLRecord_Target)
+
+	if err := protojson.Unmarshal(data, msg); err != nil {
+		return err
+	}
+
+	*t = *TargetInfoFromGRPCMessage(msg)
+
+	return nil
+}

--- a/v2/acl/json.go
+++ b/v2/acl/json.go
@@ -11,54 +11,6 @@ var (
 	errEmptyInput = errors.New("empty input")
 )
 
-func RecordToJSON(r *Record) ([]byte, error) {
-	if r == nil {
-		return nil, errEmptyInput
-	}
-
-	msg := RecordToGRPCMessage(r)
-
-	return protojson.MarshalOptions{EmitUnpopulated: true}.Marshal(msg)
-}
-
-func RecordFromJSON(data []byte) (*Record, error) {
-	if len(data) == 0 {
-		return nil, errEmptyInput
-	}
-
-	msg := new(acl.EACLRecord)
-
-	if err := protojson.Unmarshal(data, msg); err != nil {
-		return nil, err
-	}
-
-	return RecordFromGRPCMessage(msg), nil
-}
-
-func TableToJSON(t *Table) ([]byte, error) {
-	if t == nil {
-		return nil, errEmptyInput
-	}
-
-	msg := TableToGRPCMessage(t)
-
-	return protojson.MarshalOptions{EmitUnpopulated: true}.Marshal(msg)
-}
-
-func TableFromJSON(data []byte) (*Table, error) {
-	if len(data) == 0 {
-		return nil, errEmptyInput
-	}
-
-	msg := new(acl.EACLTable)
-
-	if err := protojson.Unmarshal(data, msg); err != nil {
-		return nil, err
-	}
-
-	return TableFromGRPCMessage(msg), nil
-}
-
 func BearerTokenToJSON(t *BearerToken) ([]byte, error) {
 	if t == nil {
 		return nil, errEmptyInput
@@ -139,6 +91,26 @@ func (r *Record) UnmarshalJSON(data []byte) error {
 	}
 
 	*r = *RecordFromGRPCMessage(msg)
+
+	return nil
+}
+
+func (t *Table) MarshalJSON() ([]byte, error) {
+	return protojson.MarshalOptions{
+		EmitUnpopulated: true,
+	}.Marshal(
+		TableToGRPCMessage(t),
+	)
+}
+
+func (t *Table) UnmarshalJSON(data []byte) error {
+	msg := new(acl.EACLTable)
+
+	if err := protojson.Unmarshal(data, msg); err != nil {
+		return err
+	}
+
+	*t = *TableFromGRPCMessage(msg)
 
 	return nil
 }

--- a/v2/acl/json.go
+++ b/v2/acl/json.go
@@ -114,3 +114,23 @@ func (t *Table) UnmarshalJSON(data []byte) error {
 
 	return nil
 }
+
+func (l *TokenLifetime) MarshalJSON() ([]byte, error) {
+	return protojson.MarshalOptions{
+		EmitUnpopulated: true,
+	}.Marshal(
+		TokenLifetimeToGRPCMessage(l),
+	)
+}
+
+func (l *TokenLifetime) UnmarshalJSON(data []byte) error {
+	msg := new(acl.BearerToken_Body_TokenLifetime)
+
+	if err := protojson.Unmarshal(data, msg); err != nil {
+		return err
+	}
+
+	*l = *TokenLifetimeFromGRPCMessage(msg)
+
+	return nil
+}

--- a/v2/acl/json.go
+++ b/v2/acl/json.go
@@ -1,39 +1,9 @@
 package acl
 
 import (
-	"errors"
-
 	acl "github.com/nspcc-dev/neofs-api-go/v2/acl/grpc"
 	"google.golang.org/protobuf/encoding/protojson"
 )
-
-var (
-	errEmptyInput = errors.New("empty input")
-)
-
-func BearerTokenToJSON(t *BearerToken) ([]byte, error) {
-	if t == nil {
-		return nil, errEmptyInput
-	}
-
-	msg := BearerTokenToGRPCMessage(t)
-
-	return protojson.MarshalOptions{EmitUnpopulated: true}.Marshal(msg)
-}
-
-func BearerTokenFromJSON(data []byte) (*BearerToken, error) {
-	if len(data) == 0 {
-		return nil, errEmptyInput
-	}
-
-	msg := new(acl.BearerToken)
-
-	if err := protojson.Unmarshal(data, msg); err != nil {
-		return nil, err
-	}
-
-	return BearerTokenFromGRPCMessage(msg), nil
-}
 
 func (f *HeaderFilter) MarshalJSON() ([]byte, error) {
 	return protojson.MarshalOptions{
@@ -151,6 +121,26 @@ func (bt *BearerTokenBody) UnmarshalJSON(data []byte) error {
 	}
 
 	*bt = *BearerTokenBodyFromGRPCMessage(msg)
+
+	return nil
+}
+
+func (bt *BearerToken) MarshalJSON() ([]byte, error) {
+	return protojson.MarshalOptions{
+		EmitUnpopulated: true,
+	}.Marshal(
+		BearerTokenToGRPCMessage(bt),
+	)
+}
+
+func (bt *BearerToken) UnmarshalJSON(data []byte) error {
+	msg := new(acl.BearerToken)
+
+	if err := protojson.Unmarshal(data, msg); err != nil {
+		return err
+	}
+
+	*bt = *BearerTokenFromGRPCMessage(msg)
 
 	return nil
 }

--- a/v2/acl/json.go
+++ b/v2/acl/json.go
@@ -134,3 +134,23 @@ func (l *TokenLifetime) UnmarshalJSON(data []byte) error {
 
 	return nil
 }
+
+func (bt *BearerTokenBody) MarshalJSON() ([]byte, error) {
+	return protojson.MarshalOptions{
+		EmitUnpopulated: true,
+	}.Marshal(
+		BearerTokenBodyToGRPCMessage(bt),
+	)
+}
+
+func (bt *BearerTokenBody) UnmarshalJSON(data []byte) error {
+	msg := new(acl.BearerToken_Body)
+
+	if err := protojson.Unmarshal(data, msg); err != nil {
+		return err
+	}
+
+	*bt = *BearerTokenBodyFromGRPCMessage(msg)
+
+	return nil
+}

--- a/v2/acl/json.go
+++ b/v2/acl/json.go
@@ -82,3 +82,23 @@ func BearerTokenFromJSON(data []byte) (*BearerToken, error) {
 
 	return BearerTokenFromGRPCMessage(msg), nil
 }
+
+func (f *HeaderFilter) MarshalJSON() ([]byte, error) {
+	return protojson.MarshalOptions{
+		EmitUnpopulated: true,
+	}.Marshal(
+		HeaderFilterToGRPCMessage(f),
+	)
+}
+
+func (f *HeaderFilter) UnmarshalJSON(data []byte) error {
+	msg := new(acl.EACLRecord_Filter)
+
+	if err := protojson.Unmarshal(data, msg); err != nil {
+		return err
+	}
+
+	*f = *HeaderFilterFromGRPCMessage(msg)
+
+	return nil
+}

--- a/v2/acl/json.go
+++ b/v2/acl/json.go
@@ -122,3 +122,23 @@ func (t *Target) UnmarshalJSON(data []byte) error {
 
 	return nil
 }
+
+func (r *Record) MarshalJSON() ([]byte, error) {
+	return protojson.MarshalOptions{
+		EmitUnpopulated: true,
+	}.Marshal(
+		RecordToGRPCMessage(r),
+	)
+}
+
+func (r *Record) UnmarshalJSON(data []byte) error {
+	msg := new(acl.EACLRecord)
+
+	if err := protojson.Unmarshal(data, msg); err != nil {
+		return err
+	}
+
+	*r = *RecordFromGRPCMessage(msg)
+
+	return nil
+}

--- a/v2/acl/json_test.go
+++ b/v2/acl/json_test.go
@@ -64,3 +64,15 @@ func TestBearerTokenJSON(t *testing.T) {
 		require.Equal(t, exp, got)
 	})
 }
+
+func TestFilterJSON(t *testing.T) {
+	f := generateFilter(acl.HeaderTypeObject, "key", "value")
+
+	data, err := f.MarshalJSON()
+	require.NoError(t, err)
+
+	f2 := new(acl.HeaderFilter)
+	require.NoError(t, f2.UnmarshalJSON(data))
+
+	require.Equal(t, f, f2)
+}

--- a/v2/acl/json_test.go
+++ b/v2/acl/json_test.go
@@ -7,50 +7,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestRecordJSON(t *testing.T) {
-	exp := generateRecord(false)
-
-	t.Run("non empty", func(t *testing.T) {
-		data, err := acl.RecordToJSON(exp)
-		require.NoError(t, err)
-
-		got, err := acl.RecordFromJSON(data)
-		require.NoError(t, err)
-
-		require.Equal(t, exp, got)
-	})
-
-	t.Run("empty", func(t *testing.T) {
-		_, err := acl.RecordToJSON(nil)
-		require.Error(t, err)
-
-		_, err = acl.RecordFromJSON(nil)
-		require.Error(t, err)
-	})
-}
-
-func TestEACLTableJSON(t *testing.T) {
-	exp := generateEACL()
-
-	t.Run("non empty", func(t *testing.T) {
-		data, err := acl.TableToJSON(exp)
-		require.NoError(t, err)
-
-		got, err := acl.TableFromJSON(data)
-		require.NoError(t, err)
-
-		require.Equal(t, exp, got)
-	})
-
-	t.Run("empty", func(t *testing.T) {
-		_, err := acl.TableToJSON(nil)
-		require.Error(t, err)
-
-		_, err = acl.TableFromJSON(nil)
-		require.Error(t, err)
-	})
-}
-
 func TestBearerTokenJSON(t *testing.T) {
 	exp := generateBearerToken("token")
 
@@ -87,4 +43,17 @@ func TestTargetJSON(t *testing.T) {
 	require.NoError(t, tar2.UnmarshalJSON(data))
 
 	require.Equal(t, tar, tar2)
+}
+
+func TestTable_MarshalJSON(t *testing.T) {
+	tab := new(acl.Table)
+	tab.SetRecords([]*acl.Record{generateRecord(false)})
+
+	data, err := tab.MarshalJSON()
+	require.NoError(t, err)
+
+	tab2 := new(acl.Table)
+	require.NoError(t, tab2.UnmarshalJSON(data))
+
+	require.Equal(t, tab, tab2)
 }

--- a/v2/acl/json_test.go
+++ b/v2/acl/json_test.go
@@ -8,17 +8,15 @@ import (
 )
 
 func TestBearerTokenJSON(t *testing.T) {
-	exp := generateBearerToken("token")
+	b := generateBearerToken("id")
 
-	t.Run("non empty", func(t *testing.T) {
-		data, err := acl.BearerTokenToJSON(exp)
-		require.NoError(t, err)
+	data, err := b.MarshalJSON()
+	require.NoError(t, err)
 
-		got, err := acl.BearerTokenFromJSON(data)
-		require.NoError(t, err)
+	b2 := new(acl.BearerToken)
+	require.NoError(t, b2.UnmarshalJSON(data))
 
-		require.Equal(t, exp, got)
-	})
+	require.Equal(t, b, b2)
 }
 
 func TestFilterJSON(t *testing.T) {

--- a/v2/acl/json_test.go
+++ b/v2/acl/json_test.go
@@ -57,3 +57,15 @@ func TestTable_MarshalJSON(t *testing.T) {
 
 	require.Equal(t, tab, tab2)
 }
+
+func TestTokenLifetimeJSON(t *testing.T) {
+	l := generateLifetime(1, 2, 3)
+
+	data, err := l.MarshalJSON()
+	require.NoError(t, err)
+
+	l2 := new(acl.TokenLifetime)
+	require.NoError(t, l2.UnmarshalJSON(data))
+
+	require.Equal(t, l, l2)
+}

--- a/v2/acl/json_test.go
+++ b/v2/acl/json_test.go
@@ -76,3 +76,15 @@ func TestFilterJSON(t *testing.T) {
 
 	require.Equal(t, f, f2)
 }
+
+func TestTargetJSON(t *testing.T) {
+	tar := generateTarget(acl.RoleSystem, 3)
+
+	data, err := tar.MarshalJSON()
+	require.NoError(t, err)
+
+	tar2 := new(acl.Target)
+	require.NoError(t, tar2.UnmarshalJSON(data))
+
+	require.Equal(t, tar, tar2)
+}

--- a/v2/acl/json_test.go
+++ b/v2/acl/json_test.go
@@ -69,3 +69,15 @@ func TestTokenLifetimeJSON(t *testing.T) {
 
 	require.Equal(t, l, l2)
 }
+
+func TestBearerTokenBodyJSON(t *testing.T) {
+	b := generateBearerTokenBody("id")
+
+	data, err := b.MarshalJSON()
+	require.NoError(t, err)
+
+	b2 := new(acl.BearerTokenBody)
+	require.NoError(t, b2.UnmarshalJSON(data))
+
+	require.Equal(t, b, b2)
+}

--- a/v2/acl/marshal.go
+++ b/v2/acl/marshal.go
@@ -359,6 +359,17 @@ func (l *TokenLifetime) StableSize() (size int) {
 	return size
 }
 
+func (l *TokenLifetime) Unmarshal(data []byte) error {
+	m := new(acl.BearerToken_Body_TokenLifetime)
+	if err := proto.Unmarshal(data, m); err != nil {
+		return err
+	}
+
+	*l = *TokenLifetimeFromGRPCMessage(m)
+
+	return nil
+}
+
 func (bt *BearerTokenBody) StableMarshal(buf []byte) ([]byte, error) {
 	if bt == nil {
 		return []byte{}, nil

--- a/v2/acl/marshal.go
+++ b/v2/acl/marshal.go
@@ -94,6 +94,17 @@ func (t *Table) StableSize() (size int) {
 	return size
 }
 
+func (t *Table) Unmarshal(data []byte) error {
+	m := new(acl.EACLTable)
+	if err := proto.Unmarshal(data, m); err != nil {
+		return err
+	}
+
+	*t = *TableFromGRPCMessage(m)
+
+	return nil
+}
+
 // StableMarshal marshals unified acl record structure in a protobuf
 // compatible way without field order shuffle.
 func (r *Record) StableMarshal(buf []byte) ([]byte, error) {

--- a/v2/acl/marshal.go
+++ b/v2/acl/marshal.go
@@ -278,6 +278,17 @@ func (t *Target) StableSize() (size int) {
 	return size
 }
 
+func (t *Target) Unmarshal(data []byte) error {
+	m := new(acl.EACLRecord_Target)
+	if err := proto.Unmarshal(data, m); err != nil {
+		return err
+	}
+
+	*t = *TargetInfoFromGRPCMessage(m)
+
+	return nil
+}
+
 func (l *TokenLifetime) StableMarshal(buf []byte) ([]byte, error) {
 	if l == nil {
 		return []byte{}, nil

--- a/v2/acl/marshal.go
+++ b/v2/acl/marshal.go
@@ -1,7 +1,9 @@
 package acl
 
 import (
-	"github.com/nspcc-dev/neofs-api-go/util/proto"
+	protoutil "github.com/nspcc-dev/neofs-api-go/util/proto"
+	acl "github.com/nspcc-dev/neofs-api-go/v2/acl/grpc"
+	"google.golang.org/protobuf/proto"
 )
 
 const (
@@ -50,14 +52,14 @@ func (t *Table) StableMarshal(buf []byte) ([]byte, error) {
 		err       error
 	)
 
-	n, err = proto.NestedStructureMarshal(tableVersionField, buf[offset:], t.version)
+	n, err = protoutil.NestedStructureMarshal(tableVersionField, buf[offset:], t.version)
 	if err != nil {
 		return nil, err
 	}
 
 	offset += n
 
-	n, err = proto.NestedStructureMarshal(tableContainerIDField, buf[offset:], t.cid)
+	n, err = protoutil.NestedStructureMarshal(tableContainerIDField, buf[offset:], t.cid)
 	if err != nil {
 		return nil, err
 	}
@@ -65,7 +67,7 @@ func (t *Table) StableMarshal(buf []byte) ([]byte, error) {
 	offset += n
 
 	for i := range t.records {
-		n, err = proto.NestedStructureMarshal(tableRecordsField, buf[offset:], t.records[i])
+		n, err = protoutil.NestedStructureMarshal(tableRecordsField, buf[offset:], t.records[i])
 		if err != nil {
 			return nil, err
 		}
@@ -82,11 +84,11 @@ func (t *Table) StableSize() (size int) {
 		return 0
 	}
 
-	size += proto.NestedStructureSize(tableVersionField, t.version)
-	size += proto.NestedStructureSize(tableContainerIDField, t.cid)
+	size += protoutil.NestedStructureSize(tableVersionField, t.version)
+	size += protoutil.NestedStructureSize(tableContainerIDField, t.cid)
 
 	for i := range t.records {
-		size += proto.NestedStructureSize(tableRecordsField, t.records[i])
+		size += protoutil.NestedStructureSize(tableRecordsField, t.records[i])
 	}
 
 	return size
@@ -108,14 +110,14 @@ func (r *Record) StableMarshal(buf []byte) ([]byte, error) {
 		err       error
 	)
 
-	n, err = proto.EnumMarshal(recordOperationField, buf[offset:], int32(r.op))
+	n, err = protoutil.EnumMarshal(recordOperationField, buf[offset:], int32(r.op))
 	if err != nil {
 		return nil, err
 	}
 
 	offset += n
 
-	n, err = proto.EnumMarshal(recordActionField, buf[offset:], int32(r.action))
+	n, err = protoutil.EnumMarshal(recordActionField, buf[offset:], int32(r.action))
 	if err != nil {
 		return nil, err
 	}
@@ -123,7 +125,7 @@ func (r *Record) StableMarshal(buf []byte) ([]byte, error) {
 	offset += n
 
 	for i := range r.filters {
-		n, err = proto.NestedStructureMarshal(recordFiltersField, buf[offset:], r.filters[i])
+		n, err = protoutil.NestedStructureMarshal(recordFiltersField, buf[offset:], r.filters[i])
 		if err != nil {
 			return nil, err
 		}
@@ -132,7 +134,7 @@ func (r *Record) StableMarshal(buf []byte) ([]byte, error) {
 	}
 
 	for i := range r.targets {
-		n, err = proto.NestedStructureMarshal(recordTargetsField, buf[offset:], r.targets[i])
+		n, err = protoutil.NestedStructureMarshal(recordTargetsField, buf[offset:], r.targets[i])
 		if err != nil {
 			return nil, err
 		}
@@ -149,15 +151,15 @@ func (r *Record) StableSize() (size int) {
 		return 0
 	}
 
-	size += proto.EnumSize(recordOperationField, int32(r.op))
-	size += proto.EnumSize(recordActionField, int32(r.action))
+	size += protoutil.EnumSize(recordOperationField, int32(r.op))
+	size += protoutil.EnumSize(recordActionField, int32(r.action))
 
 	for i := range r.filters {
-		size += proto.NestedStructureSize(recordFiltersField, r.filters[i])
+		size += protoutil.NestedStructureSize(recordFiltersField, r.filters[i])
 	}
 
 	for i := range r.targets {
-		size += proto.NestedStructureSize(recordTargetsField, r.targets[i])
+		size += protoutil.NestedStructureSize(recordTargetsField, r.targets[i])
 	}
 
 	return size
@@ -179,28 +181,28 @@ func (f *HeaderFilter) StableMarshal(buf []byte) ([]byte, error) {
 		err       error
 	)
 
-	n, err = proto.EnumMarshal(filterHeaderTypeField, buf[offset:], int32(f.hdrType))
+	n, err = protoutil.EnumMarshal(filterHeaderTypeField, buf[offset:], int32(f.hdrType))
 	if err != nil {
 		return nil, err
 	}
 
 	offset += n
 
-	n, err = proto.EnumMarshal(filterMatchTypeField, buf[offset:], int32(f.matchType))
+	n, err = protoutil.EnumMarshal(filterMatchTypeField, buf[offset:], int32(f.matchType))
 	if err != nil {
 		return nil, err
 	}
 
 	offset += n
 
-	n, err = proto.StringMarshal(filterNameField, buf[offset:], f.key)
+	n, err = protoutil.StringMarshal(filterNameField, buf[offset:], f.key)
 	if err != nil {
 		return nil, err
 	}
 
 	offset += n
 
-	_, err = proto.StringMarshal(filterValueField, buf[offset:], f.value)
+	_, err = protoutil.StringMarshal(filterValueField, buf[offset:], f.value)
 	if err != nil {
 		return nil, err
 	}
@@ -214,12 +216,23 @@ func (f *HeaderFilter) StableSize() (size int) {
 		return 0
 	}
 
-	size += proto.EnumSize(filterHeaderTypeField, int32(f.hdrType))
-	size += proto.EnumSize(filterMatchTypeField, int32(f.matchType))
-	size += proto.StringSize(filterNameField, f.key)
-	size += proto.StringSize(filterValueField, f.value)
+	size += protoutil.EnumSize(filterHeaderTypeField, int32(f.hdrType))
+	size += protoutil.EnumSize(filterMatchTypeField, int32(f.matchType))
+	size += protoutil.StringSize(filterNameField, f.key)
+	size += protoutil.StringSize(filterValueField, f.value)
 
 	return size
+}
+
+func (f *HeaderFilter) Unmarshal(data []byte) error {
+	m := new(acl.EACLRecord_Filter)
+	if err := proto.Unmarshal(data, m); err != nil {
+		return err
+	}
+
+	*f = *HeaderFilterFromGRPCMessage(m)
+
+	return nil
 }
 
 // StableMarshal marshals unified role info structure in a protobuf
@@ -238,14 +251,14 @@ func (t *Target) StableMarshal(buf []byte) ([]byte, error) {
 		err       error
 	)
 
-	n, err = proto.EnumMarshal(targetTypeField, buf[offset:], int32(t.role))
+	n, err = protoutil.EnumMarshal(targetTypeField, buf[offset:], int32(t.role))
 	if err != nil {
 		return nil, err
 	}
 
 	offset += n
 
-	_, err = proto.RepeatedBytesMarshal(targetKeysField, buf[offset:], t.keys)
+	_, err = protoutil.RepeatedBytesMarshal(targetKeysField, buf[offset:], t.keys)
 	if err != nil {
 		return nil, err
 	}
@@ -259,8 +272,8 @@ func (t *Target) StableSize() (size int) {
 		return 0
 	}
 
-	size += proto.EnumSize(targetTypeField, int32(t.role))
-	size += proto.RepeatedBytesSize(targetKeysField, t.keys)
+	size += protoutil.EnumSize(targetTypeField, int32(t.role))
+	size += protoutil.RepeatedBytesSize(targetKeysField, t.keys)
 
 	return size
 }
@@ -279,21 +292,21 @@ func (l *TokenLifetime) StableMarshal(buf []byte) ([]byte, error) {
 		err       error
 	)
 
-	n, err = proto.UInt64Marshal(lifetimeExpirationField, buf[offset:], l.exp)
+	n, err = protoutil.UInt64Marshal(lifetimeExpirationField, buf[offset:], l.exp)
 	if err != nil {
 		return nil, err
 	}
 
 	offset += n
 
-	n, err = proto.UInt64Marshal(lifetimeNotValidBeforeField, buf[offset:], l.nbf)
+	n, err = protoutil.UInt64Marshal(lifetimeNotValidBeforeField, buf[offset:], l.nbf)
 	if err != nil {
 		return nil, err
 	}
 
 	offset += n
 
-	_, err = proto.UInt64Marshal(lifetimeIssuedAtField, buf[offset:], l.iat)
+	_, err = protoutil.UInt64Marshal(lifetimeIssuedAtField, buf[offset:], l.iat)
 	if err != nil {
 		return nil, err
 	}
@@ -306,9 +319,9 @@ func (l *TokenLifetime) StableSize() (size int) {
 		return 0
 	}
 
-	size += proto.UInt64Size(lifetimeExpirationField, l.exp)
-	size += proto.UInt64Size(lifetimeNotValidBeforeField, l.nbf)
-	size += proto.UInt64Size(lifetimeIssuedAtField, l.iat)
+	size += protoutil.UInt64Size(lifetimeExpirationField, l.exp)
+	size += protoutil.UInt64Size(lifetimeNotValidBeforeField, l.nbf)
+	size += protoutil.UInt64Size(lifetimeIssuedAtField, l.iat)
 
 	return size
 }
@@ -327,21 +340,21 @@ func (bt *BearerTokenBody) StableMarshal(buf []byte) ([]byte, error) {
 		err       error
 	)
 
-	n, err = proto.NestedStructureMarshal(bearerTokenBodyACLField, buf[offset:], bt.eacl)
+	n, err = protoutil.NestedStructureMarshal(bearerTokenBodyACLField, buf[offset:], bt.eacl)
 	if err != nil {
 		return nil, err
 	}
 
 	offset += n
 
-	n, err = proto.NestedStructureMarshal(bearerTokenBodyOwnerField, buf[offset:], bt.ownerID)
+	n, err = protoutil.NestedStructureMarshal(bearerTokenBodyOwnerField, buf[offset:], bt.ownerID)
 	if err != nil {
 		return nil, err
 	}
 
 	offset += n
 
-	_, err = proto.NestedStructureMarshal(bearerTokenBodyLifetimeField, buf[offset:], bt.lifetime)
+	_, err = protoutil.NestedStructureMarshal(bearerTokenBodyLifetimeField, buf[offset:], bt.lifetime)
 	if err != nil {
 		return nil, err
 	}
@@ -354,9 +367,9 @@ func (bt *BearerTokenBody) StableSize() (size int) {
 		return 0
 	}
 
-	size += proto.NestedStructureSize(bearerTokenBodyACLField, bt.eacl)
-	size += proto.NestedStructureSize(bearerTokenBodyOwnerField, bt.ownerID)
-	size += proto.NestedStructureSize(bearerTokenBodyLifetimeField, bt.lifetime)
+	size += protoutil.NestedStructureSize(bearerTokenBodyACLField, bt.eacl)
+	size += protoutil.NestedStructureSize(bearerTokenBodyOwnerField, bt.ownerID)
+	size += protoutil.NestedStructureSize(bearerTokenBodyLifetimeField, bt.lifetime)
 
 	return size
 }
@@ -375,14 +388,14 @@ func (bt *BearerToken) StableMarshal(buf []byte) ([]byte, error) {
 		err       error
 	)
 
-	n, err = proto.NestedStructureMarshal(bearerTokenBodyField, buf[offset:], bt.body)
+	n, err = protoutil.NestedStructureMarshal(bearerTokenBodyField, buf[offset:], bt.body)
 	if err != nil {
 		return nil, err
 	}
 
 	offset += n
 
-	_, err = proto.NestedStructureMarshal(bearerTokenSignatureField, buf[offset:], bt.sig)
+	_, err = protoutil.NestedStructureMarshal(bearerTokenSignatureField, buf[offset:], bt.sig)
 	if err != nil {
 		return nil, err
 	}
@@ -395,8 +408,8 @@ func (bt *BearerToken) StableSize() (size int) {
 		return 0
 	}
 
-	size += proto.NestedStructureSize(bearerTokenBodyField, bt.body)
-	size += proto.NestedStructureSize(bearerTokenSignatureField, bt.sig)
+	size += protoutil.NestedStructureSize(bearerTokenBodyField, bt.body)
+	size += protoutil.NestedStructureSize(bearerTokenSignatureField, bt.sig)
 
 	return size
 }

--- a/v2/acl/marshal.go
+++ b/v2/acl/marshal.go
@@ -165,6 +165,17 @@ func (r *Record) StableSize() (size int) {
 	return size
 }
 
+func (r *Record) Unmarshal(data []byte) error {
+	m := new(acl.EACLRecord)
+	if err := proto.Unmarshal(data, m); err != nil {
+		return err
+	}
+
+	*r = *RecordFromGRPCMessage(m)
+
+	return nil
+}
+
 // StableMarshal marshals unified header filter structure in a protobuf
 // compatible way without field order shuffle.
 func (f *HeaderFilter) StableMarshal(buf []byte) ([]byte, error) {

--- a/v2/acl/marshal.go
+++ b/v2/acl/marshal.go
@@ -418,6 +418,17 @@ func (bt *BearerTokenBody) StableSize() (size int) {
 	return size
 }
 
+func (bt *BearerTokenBody) Unmarshal(data []byte) error {
+	m := new(acl.BearerToken_Body)
+	if err := proto.Unmarshal(data, m); err != nil {
+		return err
+	}
+
+	*bt = *BearerTokenBodyFromGRPCMessage(m)
+
+	return nil
+}
+
 func (bt *BearerToken) StableMarshal(buf []byte) ([]byte, error) {
 	if bt == nil {
 		return []byte{}, nil

--- a/v2/acl/marshal.go
+++ b/v2/acl/marshal.go
@@ -468,3 +468,14 @@ func (bt *BearerToken) StableSize() (size int) {
 
 	return size
 }
+
+func (bt *BearerToken) Unmarshal(data []byte) error {
+	m := new(acl.BearerToken)
+	if err := proto.Unmarshal(data, m); err != nil {
+		return err
+	}
+
+	*bt = *BearerTokenFromGRPCMessage(m)
+
+	return nil
+}

--- a/v2/acl/marshal_test.go
+++ b/v2/acl/marshal_test.go
@@ -136,7 +136,6 @@ func TestHeaderFilter_StableMarshal(t *testing.T) {
 
 func TestTargetInfo_StableMarshal(t *testing.T) {
 	targetFrom := generateTarget(acl.RoleUser, 2)
-	transport := new(grpc.EACLRecord_Target)
 
 	t.Run("non empty", func(t *testing.T) {
 		targetFrom.SetRole(acl.RoleUser)
@@ -148,10 +147,9 @@ func TestTargetInfo_StableMarshal(t *testing.T) {
 		wire, err := targetFrom.StableMarshal(nil)
 		require.NoError(t, err)
 
-		err = goproto.Unmarshal(wire, transport)
-		require.NoError(t, err)
+		targetTo := new(acl.Target)
+		require.NoError(t, targetTo.Unmarshal(wire))
 
-		targetTo := acl.TargetInfoFromGRPCMessage(transport)
 		require.Equal(t, targetFrom, targetTo)
 	})
 }

--- a/v2/acl/marshal_test.go
+++ b/v2/acl/marshal_test.go
@@ -5,10 +5,8 @@ import (
 	"testing"
 
 	"github.com/nspcc-dev/neofs-api-go/v2/acl"
-	grpc "github.com/nspcc-dev/neofs-api-go/v2/acl/grpc"
 	"github.com/nspcc-dev/neofs-api-go/v2/refs"
 	"github.com/stretchr/testify/require"
-	goproto "google.golang.org/protobuf/proto"
 )
 
 func generateTarget(u acl.Role, k int) *acl.Target {
@@ -226,16 +224,14 @@ func TestBearerTokenBody_StableMarshal(t *testing.T) {
 
 func TestBearerToken_StableMarshal(t *testing.T) {
 	bearerTokenFrom := generateBearerToken("Bearer Token")
-	transport := new(grpc.BearerToken)
 
 	t.Run("non empty", func(t *testing.T) {
 		wire, err := bearerTokenFrom.StableMarshal(nil)
 		require.NoError(t, err)
 
-		err = goproto.Unmarshal(wire, transport)
-		require.NoError(t, err)
+		bearerTokenTo := new(acl.BearerToken)
+		require.NoError(t, bearerTokenTo.Unmarshal(wire))
 
-		bearerTokenTo := acl.BearerTokenFromGRPCMessage(transport)
 		require.Equal(t, bearerTokenFrom, bearerTokenTo)
 	})
 }

--- a/v2/acl/marshal_test.go
+++ b/v2/acl/marshal_test.go
@@ -117,7 +117,6 @@ func generateBearerToken(id string) *acl.BearerToken {
 
 func TestHeaderFilter_StableMarshal(t *testing.T) {
 	filterFrom := generateFilter(acl.HeaderTypeObject, "CID", "Container ID Value")
-	transport := new(grpc.EACLRecord_Filter)
 
 	t.Run("non empty", func(t *testing.T) {
 		filterFrom.SetHeaderType(acl.HeaderTypeObject)
@@ -128,10 +127,9 @@ func TestHeaderFilter_StableMarshal(t *testing.T) {
 		wire, err := filterFrom.StableMarshal(nil)
 		require.NoError(t, err)
 
-		err = goproto.Unmarshal(wire, transport)
-		require.NoError(t, err)
+		filterTo := new(acl.HeaderFilter)
+		require.NoError(t, filterTo.Unmarshal(wire))
 
-		filterTo := acl.HeaderFilterFromGRPCMessage(transport)
 		require.Equal(t, filterFrom, filterTo)
 	})
 }

--- a/v2/acl/marshal_test.go
+++ b/v2/acl/marshal_test.go
@@ -156,17 +156,15 @@ func TestTargetInfo_StableMarshal(t *testing.T) {
 
 func TestRecord_StableMarshal(t *testing.T) {
 	recordFrom := generateRecord(false)
-	transport := new(grpc.EACLRecord)
 
 	t.Run("non empty", func(t *testing.T) {
 		wire, err := recordFrom.StableMarshal(nil)
 		require.NoError(t, err)
 
-		err = goproto.Unmarshal(wire, transport)
-		require.NoError(t, err)
+		to := new(acl.Record)
+		require.NoError(t, to.Unmarshal(wire))
 
-		recordTo := acl.RecordFromGRPCMessage(transport)
-		require.Equal(t, recordFrom, recordTo)
+		require.Equal(t, recordFrom, to)
 	})
 }
 

--- a/v2/acl/marshal_test.go
+++ b/v2/acl/marshal_test.go
@@ -212,16 +212,14 @@ func TestTokenLifetime_StableMarshal(t *testing.T) {
 
 func TestBearerTokenBody_StableMarshal(t *testing.T) {
 	bearerTokenBodyFrom := generateBearerTokenBody("Bearer Token Body")
-	transport := new(grpc.BearerToken_Body)
 
 	t.Run("non empty", func(t *testing.T) {
 		wire, err := bearerTokenBodyFrom.StableMarshal(nil)
 		require.NoError(t, err)
 
-		err = goproto.Unmarshal(wire, transport)
-		require.NoError(t, err)
+		bearerTokenBodyTo := new(acl.BearerTokenBody)
+		require.NoError(t, bearerTokenBodyTo.Unmarshal(wire))
 
-		bearerTokenBodyTo := acl.BearerTokenBodyFromGRPCMessage(transport)
 		require.Equal(t, bearerTokenBodyFrom, bearerTokenBodyTo)
 	})
 }

--- a/v2/acl/marshal_test.go
+++ b/v2/acl/marshal_test.go
@@ -170,7 +170,6 @@ func TestRecord_StableMarshal(t *testing.T) {
 
 func TestTable_StableMarshal(t *testing.T) {
 	tableFrom := new(acl.Table)
-	transport := new(grpc.EACLTable)
 
 	t.Run("non empty", func(t *testing.T) {
 		cid := new(refs.ContainerID)
@@ -190,10 +189,9 @@ func TestTable_StableMarshal(t *testing.T) {
 		wire, err := tableFrom.StableMarshal(nil)
 		require.NoError(t, err)
 
-		err = goproto.Unmarshal(wire, transport)
-		require.NoError(t, err)
+		tableTo := new(acl.Table)
+		require.NoError(t, tableTo.Unmarshal(wire))
 
-		tableTo := acl.TableFromGRPCMessage(transport)
 		require.Equal(t, tableFrom, tableTo)
 	})
 }

--- a/v2/acl/marshal_test.go
+++ b/v2/acl/marshal_test.go
@@ -198,16 +198,14 @@ func TestTable_StableMarshal(t *testing.T) {
 
 func TestTokenLifetime_StableMarshal(t *testing.T) {
 	lifetimeFrom := generateLifetime(10, 20, 30)
-	transport := new(grpc.BearerToken_Body_TokenLifetime)
 
 	t.Run("non empty", func(t *testing.T) {
 		wire, err := lifetimeFrom.StableMarshal(nil)
 		require.NoError(t, err)
 
-		err = goproto.Unmarshal(wire, transport)
-		require.NoError(t, err)
+		lifetimeTo := new(acl.TokenLifetime)
+		require.NoError(t, lifetimeTo.Unmarshal(wire))
 
-		lifetimeTo := acl.TokenLifetimeFromGRPCMessage(transport)
 		require.Equal(t, lifetimeFrom, lifetimeTo)
 	})
 }

--- a/v2/container/json.go
+++ b/v2/container/json.go
@@ -1,39 +1,9 @@
 package container
 
 import (
-	"errors"
-
 	container "github.com/nspcc-dev/neofs-api-go/v2/container/grpc"
 	"google.golang.org/protobuf/encoding/protojson"
 )
-
-var (
-	errEmptyInput = errors.New("empty input")
-)
-
-func ContainerToJSON(c *Container) ([]byte, error) {
-	if c == nil {
-		return nil, errEmptyInput
-	}
-
-	msg := ContainerToGRPCMessage(c)
-
-	return protojson.MarshalOptions{EmitUnpopulated: true}.Marshal(msg)
-}
-
-func ContainerFromJSON(data []byte) (*Container, error) {
-	if len(data) == 0 {
-		return nil, errEmptyInput
-	}
-
-	msg := new(container.Container)
-
-	if err := protojson.Unmarshal(data, msg); err != nil {
-		return nil, err
-	}
-
-	return ContainerFromGRPCMessage(msg), nil
-}
 
 func (a *Attribute) MarshalJSON() ([]byte, error) {
 	return protojson.MarshalOptions{
@@ -51,6 +21,26 @@ func (a *Attribute) UnmarshalJSON(data []byte) error {
 	}
 
 	*a = *AttributeFromGRPCMessage(msg)
+
+	return nil
+}
+
+func (c *Container) MarshalJSON() ([]byte, error) {
+	return protojson.MarshalOptions{
+		EmitUnpopulated: true,
+	}.Marshal(
+		ContainerToGRPCMessage(c),
+	)
+}
+
+func (c *Container) UnmarshalJSON(data []byte) error {
+	msg := new(container.Container)
+
+	if err := protojson.Unmarshal(data, msg); err != nil {
+		return err
+	}
+
+	*c = *ContainerFromGRPCMessage(msg)
 
 	return nil
 }

--- a/v2/container/json.go
+++ b/v2/container/json.go
@@ -34,3 +34,23 @@ func ContainerFromJSON(data []byte) (*Container, error) {
 
 	return ContainerFromGRPCMessage(msg), nil
 }
+
+func (a *Attribute) MarshalJSON() ([]byte, error) {
+	return protojson.MarshalOptions{
+		EmitUnpopulated: true,
+	}.Marshal(
+		AttributeToGRPCMessage(a),
+	)
+}
+
+func (a *Attribute) UnmarshalJSON(data []byte) error {
+	msg := new(container.Container_Attribute)
+
+	if err := protojson.Unmarshal(data, msg); err != nil {
+		return err
+	}
+
+	*a = *AttributeFromGRPCMessage(msg)
+
+	return nil
+}

--- a/v2/container/json_test.go
+++ b/v2/container/json_test.go
@@ -8,25 +8,15 @@ import (
 )
 
 func TestContainerJSON(t *testing.T) {
-	exp := generateContainer("container")
+	c := generateContainer("nonce")
 
-	t.Run("non empty", func(t *testing.T) {
-		data, err := container.ContainerToJSON(exp)
-		require.NoError(t, err)
+	data, err := c.MarshalJSON()
+	require.NoError(t, err)
 
-		got, err := container.ContainerFromJSON(data)
-		require.NoError(t, err)
+	c2 := new(container.Container)
+	require.NoError(t, c2.UnmarshalJSON(data))
 
-		require.Equal(t, exp, got)
-	})
-
-	t.Run("empty", func(t *testing.T) {
-		_, err := container.ContainerToJSON(nil)
-		require.Error(t, err)
-
-		_, err = container.ContainerFromJSON(nil)
-		require.Error(t, err)
-	})
+	require.Equal(t, c, c2)
 }
 
 func TestAttributeJSON(t *testing.T) {

--- a/v2/container/json_test.go
+++ b/v2/container/json_test.go
@@ -28,3 +28,15 @@ func TestContainerJSON(t *testing.T) {
 		require.Error(t, err)
 	})
 }
+
+func TestAttributeJSON(t *testing.T) {
+	b := generateAttribute("key", "value")
+
+	data, err := b.MarshalJSON()
+	require.NoError(t, err)
+
+	b2 := new(container.Attribute)
+	require.NoError(t, b2.UnmarshalJSON(data))
+
+	require.Equal(t, b, b2)
+}

--- a/v2/container/marshal.go
+++ b/v2/container/marshal.go
@@ -171,6 +171,17 @@ func (c *Container) StableSize() (size int) {
 	return size
 }
 
+func (c *Container) Unmarshal(data []byte) error {
+	m := new(container.Container)
+	if err := proto.Unmarshal(data, m); err != nil {
+		return err
+	}
+
+	*c = *ContainerFromGRPCMessage(m)
+
+	return nil
+}
+
 func (r *PutRequestBody) StableMarshal(buf []byte) ([]byte, error) {
 	if r == nil {
 		return []byte{}, nil

--- a/v2/container/marshal.go
+++ b/v2/container/marshal.go
@@ -1,7 +1,9 @@
 package container
 
 import (
-	"github.com/nspcc-dev/neofs-api-go/util/proto"
+	protoutil "github.com/nspcc-dev/neofs-api-go/util/proto"
+	container "github.com/nspcc-dev/neofs-api-go/v2/container/grpc"
+	"google.golang.org/protobuf/proto"
 )
 
 const (
@@ -54,14 +56,14 @@ func (a *Attribute) StableMarshal(buf []byte) ([]byte, error) {
 		err       error
 	)
 
-	n, err = proto.StringMarshal(attributeKeyField, buf[offset:], a.key)
+	n, err = protoutil.StringMarshal(attributeKeyField, buf[offset:], a.key)
 	if err != nil {
 		return nil, err
 	}
 
 	offset += n
 
-	_, err = proto.StringMarshal(attributeValueField, buf[offset:], a.val)
+	_, err = protoutil.StringMarshal(attributeValueField, buf[offset:], a.val)
 	if err != nil {
 		return nil, err
 	}
@@ -74,10 +76,21 @@ func (a *Attribute) StableSize() (size int) {
 		return 0
 	}
 
-	size += proto.StringSize(attributeKeyField, a.key)
-	size += proto.StringSize(attributeValueField, a.val)
+	size += protoutil.StringSize(attributeKeyField, a.key)
+	size += protoutil.StringSize(attributeValueField, a.val)
 
 	return size
+}
+
+func (a *Attribute) Unmarshal(data []byte) error {
+	m := new(container.Container_Attribute)
+	if err := proto.Unmarshal(data, m); err != nil {
+		return err
+	}
+
+	*a = *AttributeFromGRPCMessage(m)
+
+	return nil
 }
 
 func (c *Container) StableMarshal(buf []byte) ([]byte, error) {
@@ -94,28 +107,28 @@ func (c *Container) StableMarshal(buf []byte) ([]byte, error) {
 		err       error
 	)
 
-	n, err = proto.NestedStructureMarshal(containerVersionField, buf[offset:], c.version)
+	n, err = protoutil.NestedStructureMarshal(containerVersionField, buf[offset:], c.version)
 	if err != nil {
 		return nil, err
 	}
 
 	offset += n
 
-	n, err = proto.NestedStructureMarshal(containerOwnerField, buf[offset:], c.ownerID)
+	n, err = protoutil.NestedStructureMarshal(containerOwnerField, buf[offset:], c.ownerID)
 	if err != nil {
 		return nil, err
 	}
 
 	offset += n
 
-	n, err = proto.BytesMarshal(containerNonceField, buf[offset:], c.nonce)
+	n, err = protoutil.BytesMarshal(containerNonceField, buf[offset:], c.nonce)
 	if err != nil {
 		return nil, err
 	}
 
 	offset += n
 
-	n, err = proto.UInt32Marshal(containerBasicACLField, buf[offset:], c.basicACL)
+	n, err = protoutil.UInt32Marshal(containerBasicACLField, buf[offset:], c.basicACL)
 	if err != nil {
 		return nil, err
 	}
@@ -123,7 +136,7 @@ func (c *Container) StableMarshal(buf []byte) ([]byte, error) {
 	offset += n
 
 	for i := range c.attr {
-		n, err = proto.NestedStructureMarshal(containerAttributesField, buf[offset:], c.attr[i])
+		n, err = protoutil.NestedStructureMarshal(containerAttributesField, buf[offset:], c.attr[i])
 		if err != nil {
 			return nil, err
 		}
@@ -131,7 +144,7 @@ func (c *Container) StableMarshal(buf []byte) ([]byte, error) {
 		offset += n
 	}
 
-	_, err = proto.NestedStructureMarshal(containerPlacementField, buf[offset:], c.policy)
+	_, err = protoutil.NestedStructureMarshal(containerPlacementField, buf[offset:], c.policy)
 	if err != nil {
 		return nil, err
 	}
@@ -144,16 +157,16 @@ func (c *Container) StableSize() (size int) {
 		return 0
 	}
 
-	size += proto.NestedStructureSize(containerVersionField, c.version)
-	size += proto.NestedStructureSize(containerOwnerField, c.ownerID)
-	size += proto.BytesSize(containerNonceField, c.nonce)
-	size += proto.UInt32Size(containerBasicACLField, c.basicACL)
+	size += protoutil.NestedStructureSize(containerVersionField, c.version)
+	size += protoutil.NestedStructureSize(containerOwnerField, c.ownerID)
+	size += protoutil.BytesSize(containerNonceField, c.nonce)
+	size += protoutil.UInt32Size(containerBasicACLField, c.basicACL)
 
 	for i := range c.attr {
-		size += proto.NestedStructureSize(containerAttributesField, c.attr[i])
+		size += protoutil.NestedStructureSize(containerAttributesField, c.attr[i])
 	}
 
-	size += proto.NestedStructureSize(containerPlacementField, c.policy)
+	size += protoutil.NestedStructureSize(containerPlacementField, c.policy)
 
 	return size
 }
@@ -172,14 +185,14 @@ func (r *PutRequestBody) StableMarshal(buf []byte) ([]byte, error) {
 		err       error
 	)
 
-	n, err = proto.NestedStructureMarshal(putReqBodyContainerField, buf[offset:], r.cnr)
+	n, err = protoutil.NestedStructureMarshal(putReqBodyContainerField, buf[offset:], r.cnr)
 	if err != nil {
 		return nil, err
 	}
 
 	offset += n
 
-	_, err = proto.NestedStructureMarshal(putReqBodySignatureField, buf[offset:], r.sig)
+	_, err = protoutil.NestedStructureMarshal(putReqBodySignatureField, buf[offset:], r.sig)
 	if err != nil {
 		return nil, err
 	}
@@ -192,8 +205,8 @@ func (r *PutRequestBody) StableSize() (size int) {
 		return 0
 	}
 
-	size += proto.NestedStructureSize(putReqBodyContainerField, r.cnr)
-	size += proto.NestedStructureSize(putReqBodySignatureField, r.sig)
+	size += protoutil.NestedStructureSize(putReqBodyContainerField, r.cnr)
+	size += protoutil.NestedStructureSize(putReqBodySignatureField, r.sig)
 
 	return size
 }
@@ -211,7 +224,7 @@ func (r *PutResponseBody) StableMarshal(buf []byte) ([]byte, error) {
 		err error
 	)
 
-	_, err = proto.NestedStructureMarshal(putRespBodyIDField, buf, r.cid)
+	_, err = protoutil.NestedStructureMarshal(putRespBodyIDField, buf, r.cid)
 	if err != nil {
 		return nil, err
 	}
@@ -224,7 +237,7 @@ func (r *PutResponseBody) StableSize() (size int) {
 		return 0
 	}
 
-	size += proto.NestedStructureSize(putRespBodyIDField, r.cid)
+	size += protoutil.NestedStructureSize(putRespBodyIDField, r.cid)
 
 	return size
 }
@@ -243,14 +256,14 @@ func (r *DeleteRequestBody) StableMarshal(buf []byte) ([]byte, error) {
 		err       error
 	)
 
-	n, err = proto.NestedStructureMarshal(deleteReqBodyIDField, buf[offset:], r.cid)
+	n, err = protoutil.NestedStructureMarshal(deleteReqBodyIDField, buf[offset:], r.cid)
 	if err != nil {
 		return nil, err
 	}
 
 	offset += n
 
-	_, err = proto.NestedStructureMarshal(deleteReqBodySignatureField, buf[offset:], r.sig)
+	_, err = protoutil.NestedStructureMarshal(deleteReqBodySignatureField, buf[offset:], r.sig)
 	if err != nil {
 		return nil, err
 	}
@@ -263,8 +276,8 @@ func (r *DeleteRequestBody) StableSize() (size int) {
 		return 0
 	}
 
-	size += proto.NestedStructureSize(deleteReqBodyIDField, r.cid)
-	size += proto.NestedStructureSize(deleteReqBodySignatureField, r.sig)
+	size += protoutil.NestedStructureSize(deleteReqBodyIDField, r.cid)
+	size += protoutil.NestedStructureSize(deleteReqBodySignatureField, r.sig)
 
 	return size
 }
@@ -286,7 +299,7 @@ func (r *GetRequestBody) StableMarshal(buf []byte) ([]byte, error) {
 		buf = make([]byte, r.StableSize())
 	}
 
-	_, err := proto.NestedStructureMarshal(getReqBodyIDField, buf, r.cid)
+	_, err := protoutil.NestedStructureMarshal(getReqBodyIDField, buf, r.cid)
 	if err != nil {
 		return nil, err
 	}
@@ -299,7 +312,7 @@ func (r *GetRequestBody) StableSize() (size int) {
 		return 0
 	}
 
-	size += proto.NestedStructureSize(getReqBodyIDField, r.cid)
+	size += protoutil.NestedStructureSize(getReqBodyIDField, r.cid)
 
 	return size
 }
@@ -313,7 +326,7 @@ func (r *GetResponseBody) StableMarshal(buf []byte) ([]byte, error) {
 		buf = make([]byte, r.StableSize())
 	}
 
-	_, err := proto.NestedStructureMarshal(getRespBodyContainerField, buf, r.cnr)
+	_, err := protoutil.NestedStructureMarshal(getRespBodyContainerField, buf, r.cnr)
 	if err != nil {
 		return nil, err
 	}
@@ -326,7 +339,7 @@ func (r *GetResponseBody) StableSize() (size int) {
 		return 0
 	}
 
-	size += proto.NestedStructureSize(getRespBodyContainerField, r.cnr)
+	size += protoutil.NestedStructureSize(getRespBodyContainerField, r.cnr)
 
 	return size
 }
@@ -340,7 +353,7 @@ func (r *ListRequestBody) StableMarshal(buf []byte) ([]byte, error) {
 		buf = make([]byte, r.StableSize())
 	}
 
-	_, err := proto.NestedStructureMarshal(listReqBodyOwnerField, buf, r.ownerID)
+	_, err := protoutil.NestedStructureMarshal(listReqBodyOwnerField, buf, r.ownerID)
 	if err != nil {
 		return nil, err
 	}
@@ -353,7 +366,7 @@ func (r *ListRequestBody) StableSize() (size int) {
 		return 0
 	}
 
-	size += proto.NestedStructureSize(listReqBodyOwnerField, r.ownerID)
+	size += protoutil.NestedStructureSize(listReqBodyOwnerField, r.ownerID)
 
 	return size
 }
@@ -373,7 +386,7 @@ func (r *ListResponseBody) StableMarshal(buf []byte) ([]byte, error) {
 	)
 
 	for i := range r.cidList {
-		n, err = proto.NestedStructureMarshal(listRespBodyIDsField, buf[offset:], r.cidList[i])
+		n, err = protoutil.NestedStructureMarshal(listRespBodyIDsField, buf[offset:], r.cidList[i])
 		if err != nil {
 			return nil, err
 		}
@@ -390,7 +403,7 @@ func (r *ListResponseBody) StableSize() (size int) {
 	}
 
 	for i := range r.cidList {
-		size += proto.NestedStructureSize(listRespBodyIDsField, r.cidList[i])
+		size += protoutil.NestedStructureSize(listRespBodyIDsField, r.cidList[i])
 	}
 
 	return size
@@ -410,14 +423,14 @@ func (r *SetExtendedACLRequestBody) StableMarshal(buf []byte) ([]byte, error) {
 		err       error
 	)
 
-	n, err = proto.NestedStructureMarshal(setEACLReqBodyTableField, buf[offset:], r.eacl)
+	n, err = protoutil.NestedStructureMarshal(setEACLReqBodyTableField, buf[offset:], r.eacl)
 	if err != nil {
 		return nil, err
 	}
 
 	offset += n
 
-	_, err = proto.NestedStructureMarshal(setEACLReqBodySignatureField, buf[offset:], r.sig)
+	_, err = protoutil.NestedStructureMarshal(setEACLReqBodySignatureField, buf[offset:], r.sig)
 	if err != nil {
 		return nil, err
 	}
@@ -430,8 +443,8 @@ func (r *SetExtendedACLRequestBody) StableSize() (size int) {
 		return 0
 	}
 
-	size += proto.NestedStructureSize(setEACLReqBodyTableField, r.eacl)
-	size += proto.NestedStructureSize(setEACLReqBodySignatureField, r.sig)
+	size += protoutil.NestedStructureSize(setEACLReqBodyTableField, r.eacl)
+	size += protoutil.NestedStructureSize(setEACLReqBodySignatureField, r.sig)
 
 	return size
 }
@@ -453,7 +466,7 @@ func (r *GetExtendedACLRequestBody) StableMarshal(buf []byte) ([]byte, error) {
 		buf = make([]byte, r.StableSize())
 	}
 
-	_, err := proto.NestedStructureMarshal(getEACLReqBodyIDField, buf, r.cid)
+	_, err := protoutil.NestedStructureMarshal(getEACLReqBodyIDField, buf, r.cid)
 	if err != nil {
 		return nil, err
 	}
@@ -466,7 +479,7 @@ func (r *GetExtendedACLRequestBody) StableSize() (size int) {
 		return 0
 	}
 
-	size += proto.NestedStructureSize(getEACLReqBodyIDField, r.cid)
+	size += protoutil.NestedStructureSize(getEACLReqBodyIDField, r.cid)
 
 	return size
 }
@@ -485,14 +498,14 @@ func (r *GetExtendedACLResponseBody) StableMarshal(buf []byte) ([]byte, error) {
 		err       error
 	)
 
-	n, err = proto.NestedStructureMarshal(getEACLRespBodyTableField, buf[offset:], r.eacl)
+	n, err = protoutil.NestedStructureMarshal(getEACLRespBodyTableField, buf[offset:], r.eacl)
 	if err != nil {
 		return nil, err
 	}
 
 	offset += n
 
-	_, err = proto.NestedStructureMarshal(getEACLRespBodySignatureField, buf[offset:], r.sig)
+	_, err = protoutil.NestedStructureMarshal(getEACLRespBodySignatureField, buf[offset:], r.sig)
 	if err != nil {
 		return nil, err
 	}
@@ -505,8 +518,8 @@ func (r *GetExtendedACLResponseBody) StableSize() (size int) {
 		return 0
 	}
 
-	size += proto.NestedStructureSize(getEACLRespBodyTableField, r.eacl)
-	size += proto.NestedStructureSize(getEACLRespBodySignatureField, r.sig)
+	size += protoutil.NestedStructureSize(getEACLRespBodyTableField, r.eacl)
+	size += protoutil.NestedStructureSize(getEACLRespBodySignatureField, r.sig)
 
 	return size
 }

--- a/v2/container/marshal_test.go
+++ b/v2/container/marshal_test.go
@@ -28,16 +28,14 @@ func TestAttribute_StableMarshal(t *testing.T) {
 
 func TestContainer_StableMarshal(t *testing.T) {
 	cnrFrom := generateContainer("nonce")
-	transport := new(grpc.Container)
 
 	t.Run("non empty", func(t *testing.T) {
 		wire, err := cnrFrom.StableMarshal(nil)
 		require.NoError(t, err)
 
-		err = goproto.Unmarshal(wire, transport)
-		require.NoError(t, err)
+		cnrTo := new(container.Container)
+		require.NoError(t, cnrTo.Unmarshal(wire))
 
-		cnrTo := container.ContainerFromGRPCMessage(transport)
 		require.Equal(t, cnrFrom, cnrTo)
 	})
 }

--- a/v2/container/marshal_test.go
+++ b/v2/container/marshal_test.go
@@ -14,16 +14,14 @@ import (
 
 func TestAttribute_StableMarshal(t *testing.T) {
 	attributeFrom := generateAttribute("key", "value")
-	transport := new(grpc.Container_Attribute)
 
 	t.Run("non empty", func(t *testing.T) {
 		wire, err := attributeFrom.StableMarshal(nil)
 		require.NoError(t, err)
 
-		err = goproto.Unmarshal(wire, transport)
-		require.NoError(t, err)
+		attributeTo := new(container.Attribute)
+		require.NoError(t, attributeTo.Unmarshal(wire))
 
-		attributeTo := container.AttributeFromGRPCMessage(transport)
 		require.Equal(t, attributeFrom, attributeTo)
 	})
 }

--- a/v2/netmap/json.go
+++ b/v2/netmap/json.go
@@ -1,60 +1,126 @@
 package netmap
 
 import (
-	"errors"
-
 	netmap "github.com/nspcc-dev/neofs-api-go/v2/netmap/grpc"
 	"google.golang.org/protobuf/encoding/protojson"
 )
 
-var (
-	errEmptyInput = errors.New("empty input")
-)
-
-func NodeInfoToJSON(n *NodeInfo) ([]byte, error) {
-	if n == nil {
-		return nil, errEmptyInput
-	}
-
-	msg := NodeInfoToGRPCMessage(n)
-
-	return protojson.MarshalOptions{EmitUnpopulated: true}.Marshal(msg)
+func (p *PlacementPolicy) MarshalJSON() ([]byte, error) {
+	return protojson.MarshalOptions{
+		EmitUnpopulated: true,
+	}.Marshal(
+		PlacementPolicyToGRPCMessage(p),
+	)
 }
 
-func NodeInfoFromJSON(data []byte) (*NodeInfo, error) {
-	if len(data) == 0 {
-		return nil, errEmptyInput
-	}
-
-	msg := new(netmap.NodeInfo)
-
-	if err := protojson.Unmarshal(data, msg); err != nil {
-		return nil, err
-	}
-
-	return NodeInfoFromGRPCMessage(msg), nil
-}
-
-func PlacementPolicyToJSON(n *PlacementPolicy) ([]byte, error) {
-	if n == nil {
-		return nil, errEmptyInput
-	}
-
-	msg := PlacementPolicyToGRPCMessage(n)
-
-	return protojson.MarshalOptions{EmitUnpopulated: true}.Marshal(msg)
-}
-
-func PlacementPolicyFromJSON(data []byte) (*PlacementPolicy, error) {
-	if len(data) == 0 {
-		return nil, errEmptyInput
-	}
-
+func (p *PlacementPolicy) UnmarshalJSON(data []byte) error {
 	msg := new(netmap.PlacementPolicy)
 
 	if err := protojson.Unmarshal(data, msg); err != nil {
-		return nil, err
+		return err
 	}
 
-	return PlacementPolicyFromGRPCMessage(msg), nil
+	*p = *PlacementPolicyFromGRPCMessage(msg)
+
+	return nil
+}
+
+func (f *Filter) MarshalJSON() ([]byte, error) {
+	return protojson.MarshalOptions{
+		EmitUnpopulated: true,
+	}.Marshal(
+		FilterToGRPCMessage(f),
+	)
+}
+
+func (f *Filter) UnmarshalJSON(data []byte) error {
+	msg := new(netmap.Filter)
+
+	if err := protojson.Unmarshal(data, msg); err != nil {
+		return err
+	}
+
+	*f = *FilterFromGRPCMessage(msg)
+
+	return nil
+}
+
+func (s *Selector) MarshalJSON() ([]byte, error) {
+	return protojson.MarshalOptions{
+		EmitUnpopulated: true,
+	}.Marshal(
+		SelectorToGRPCMessage(s),
+	)
+}
+
+func (s *Selector) UnmarshalJSON(data []byte) error {
+	msg := new(netmap.Selector)
+
+	if err := protojson.Unmarshal(data, msg); err != nil {
+		return err
+	}
+
+	*s = *SelectorFromGRPCMessage(msg)
+
+	return nil
+}
+
+func (r *Replica) MarshalJSON() ([]byte, error) {
+	return protojson.MarshalOptions{
+		EmitUnpopulated: true,
+	}.Marshal(
+		ReplicaToGRPCMessage(r),
+	)
+}
+
+func (r *Replica) UnmarshalJSON(data []byte) error {
+	msg := new(netmap.Replica)
+
+	if err := protojson.Unmarshal(data, msg); err != nil {
+		return err
+	}
+
+	*r = *ReplicaFromGRPCMessage(msg)
+
+	return nil
+}
+
+func (a *Attribute) MarshalJSON() ([]byte, error) {
+	return protojson.MarshalOptions{
+		EmitUnpopulated: true,
+	}.Marshal(
+		AttributeToGRPCMessage(a),
+	)
+}
+
+func (a *Attribute) UnmarshalJSON(data []byte) error {
+	msg := new(netmap.NodeInfo_Attribute)
+
+	if err := protojson.Unmarshal(data, msg); err != nil {
+		return err
+	}
+
+	*a = *AttributeFromGRPCMessage(msg)
+
+	return nil
+}
+
+func (ni *NodeInfo) MarshalJSON() ([]byte, error) {
+	return protojson.MarshalOptions{
+		EmitUnpopulated: true,
+	}.Marshal(
+		NodeInfoToGRPCMessage(ni),
+	)
+}
+
+func (ni *NodeInfo) UnmarshalJSON(data []byte) error {
+	msg := new(netmap.NodeInfo)
+
+	if err := protojson.Unmarshal(data, msg); err != nil {
+		return err
+	}
+
+	*ni = *NodeInfoFromGRPCMessage(msg)
+
+	return nil
 }

--- a/v2/netmap/json_test.go
+++ b/v2/netmap/json_test.go
@@ -7,46 +7,62 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestNodeInfoJSON(t *testing.T) {
-	exp := generateNodeInfo("public key", "/multi/addr", 2)
+func TestFilterJSON(t *testing.T) {
+	f := generateFilter("key", "value", false)
 
-	t.Run("non empty", func(t *testing.T) {
-		data, err := netmap.NodeInfoToJSON(exp)
-		require.NoError(t, err)
+	d, err := f.MarshalJSON()
+	require.NoError(t, err)
 
-		got, err := netmap.NodeInfoFromJSON(data)
-		require.NoError(t, err)
+	f2 := new(netmap.Filter)
+	require.NoError(t, f2.UnmarshalJSON(d))
 
-		require.Equal(t, exp, got)
-	})
-
-	t.Run("empty", func(t *testing.T) {
-		_, err := netmap.NodeInfoToJSON(nil)
-		require.Error(t, err)
-
-		_, err = netmap.NodeInfoFromJSON(nil)
-		require.Error(t, err)
-	})
+	require.Equal(t, f, f2)
 }
 
-func TestPlacementPolicyJSON(t *testing.T) {
-	exp := generatePolicy(3)
+func TestSelectorJSON(t *testing.T) {
+	s := generateSelector("name")
 
-	t.Run("non empty", func(t *testing.T) {
-		data, err := netmap.PlacementPolicyToJSON(exp)
-		require.NoError(t, err)
+	data, err := s.MarshalJSON()
+	require.NoError(t, err)
 
-		got, err := netmap.PlacementPolicyFromJSON(data)
-		require.NoError(t, err)
+	s2 := new(netmap.Selector)
+	require.NoError(t, s2.UnmarshalJSON(data))
 
-		require.Equal(t, exp, got)
-	})
+	require.Equal(t, s, s2)
+}
 
-	t.Run("empty", func(t *testing.T) {
-		_, err := netmap.PlacementPolicyToJSON(nil)
-		require.Error(t, err)
+func TestReplicaJSON(t *testing.T) {
+	s := generateReplica("selector")
 
-		_, err = netmap.PlacementPolicyFromJSON(nil)
-		require.Error(t, err)
-	})
+	data, err := s.MarshalJSON()
+	require.NoError(t, err)
+
+	s2 := new(netmap.Replica)
+	require.NoError(t, s2.UnmarshalJSON(data))
+
+	require.Equal(t, s, s2)
+}
+
+func TestAttributeJSON(t *testing.T) {
+	a := generateAttribute("key", "value")
+
+	data, err := a.MarshalJSON()
+	require.NoError(t, err)
+
+	a2 := new(netmap.Attribute)
+	require.NoError(t, a2.UnmarshalJSON(data))
+
+	require.Equal(t, a, a2)
+}
+
+func TestNodeInfoJSON(t *testing.T) {
+	i := generateNodeInfo("key", "value", 3)
+
+	data, err := i.MarshalJSON()
+	require.NoError(t, err)
+
+	i2 := new(netmap.NodeInfo)
+	require.NoError(t, i2.UnmarshalJSON(data))
+
+	require.Equal(t, i, i2)
 }

--- a/v2/netmap/marshal.go
+++ b/v2/netmap/marshal.go
@@ -1,7 +1,9 @@
 package netmap
 
 import (
-	"github.com/nspcc-dev/neofs-api-go/util/proto"
+	protoutil "github.com/nspcc-dev/neofs-api-go/util/proto"
+	netmap "github.com/nspcc-dev/neofs-api-go/v2/netmap/grpc"
+	"google.golang.org/protobuf/proto"
 )
 
 const (
@@ -52,28 +54,28 @@ func (f *Filter) StableMarshal(buf []byte) ([]byte, error) {
 		err       error
 	)
 
-	n, err = proto.StringMarshal(nameFilterField, buf[offset:], f.name)
+	n, err = protoutil.StringMarshal(nameFilterField, buf[offset:], f.name)
 	if err != nil {
 		return nil, err
 	}
 
 	offset += n
 
-	n, err = proto.StringMarshal(keyFilterField, buf[offset:], f.key)
+	n, err = protoutil.StringMarshal(keyFilterField, buf[offset:], f.key)
 	if err != nil {
 		return nil, err
 	}
 
 	offset += n
 
-	n, err = proto.EnumMarshal(opFilterField, buf[offset:], int32(f.op))
+	n, err = protoutil.EnumMarshal(opFilterField, buf[offset:], int32(f.op))
 	if err != nil {
 		return nil, err
 	}
 
 	offset += n
 
-	n, err = proto.StringMarshal(valueFilterField, buf[offset:], f.value)
+	n, err = protoutil.StringMarshal(valueFilterField, buf[offset:], f.value)
 	if err != nil {
 		return nil, err
 	}
@@ -81,7 +83,7 @@ func (f *Filter) StableMarshal(buf []byte) ([]byte, error) {
 	offset += n
 
 	for i := range f.filters {
-		n, err = proto.NestedStructureMarshal(filtersFilterField, buf[offset:], f.filters[i])
+		n, err = protoutil.NestedStructureMarshal(filtersFilterField, buf[offset:], f.filters[i])
 		if err != nil {
 			return nil, err
 		}
@@ -93,15 +95,26 @@ func (f *Filter) StableMarshal(buf []byte) ([]byte, error) {
 }
 
 func (f *Filter) StableSize() (size int) {
-	size += proto.StringSize(nameFilterField, f.name)
-	size += proto.StringSize(keyFilterField, f.key)
-	size += proto.EnumSize(opFilterField, int32(f.op))
-	size += proto.StringSize(valueFilterField, f.value)
+	size += protoutil.StringSize(nameFilterField, f.name)
+	size += protoutil.StringSize(keyFilterField, f.key)
+	size += protoutil.EnumSize(opFilterField, int32(f.op))
+	size += protoutil.StringSize(valueFilterField, f.value)
 	for i := range f.filters {
-		size += proto.NestedStructureSize(filtersFilterField, f.filters[i])
+		size += protoutil.NestedStructureSize(filtersFilterField, f.filters[i])
 	}
 
 	return size
+}
+
+func (f *Filter) Unmarshal(data []byte) error {
+	m := new(netmap.Filter)
+	if err := proto.Unmarshal(data, m); err != nil {
+		return err
+	}
+
+	*f = *FilterFromGRPCMessage(m)
+
+	return nil
 }
 
 func (s *Selector) StableMarshal(buf []byte) ([]byte, error) {
@@ -118,35 +131,35 @@ func (s *Selector) StableMarshal(buf []byte) ([]byte, error) {
 		err       error
 	)
 
-	n, err = proto.StringMarshal(nameSelectorField, buf[offset:], s.name)
+	n, err = protoutil.StringMarshal(nameSelectorField, buf[offset:], s.name)
 	if err != nil {
 		return nil, err
 	}
 
 	offset += n
 
-	n, err = proto.UInt32Marshal(countSelectorField, buf[offset:], s.count)
+	n, err = protoutil.UInt32Marshal(countSelectorField, buf[offset:], s.count)
 	if err != nil {
 		return nil, err
 	}
 
 	offset += n
 
-	n, err = proto.EnumMarshal(clauseSelectorField, buf[offset:], int32(s.clause))
+	n, err = protoutil.EnumMarshal(clauseSelectorField, buf[offset:], int32(s.clause))
 	if err != nil {
 		return nil, err
 	}
 
 	offset += n
 
-	n, err = proto.StringMarshal(attributeSelectorField, buf[offset:], s.attribute)
+	n, err = protoutil.StringMarshal(attributeSelectorField, buf[offset:], s.attribute)
 	if err != nil {
 		return nil, err
 	}
 
 	offset += n
 
-	n, err = proto.StringMarshal(filterSelectorField, buf[offset:], s.filter)
+	n, err = protoutil.StringMarshal(filterSelectorField, buf[offset:], s.filter)
 	if err != nil {
 		return nil, err
 	}
@@ -155,13 +168,24 @@ func (s *Selector) StableMarshal(buf []byte) ([]byte, error) {
 }
 
 func (s *Selector) StableSize() (size int) {
-	size += proto.StringSize(nameSelectorField, s.name)
-	size += proto.UInt32Size(countSelectorField, s.count)
-	size += proto.EnumSize(countSelectorField, int32(s.clause))
-	size += proto.StringSize(attributeSelectorField, s.attribute)
-	size += proto.StringSize(filterSelectorField, s.filter)
+	size += protoutil.StringSize(nameSelectorField, s.name)
+	size += protoutil.UInt32Size(countSelectorField, s.count)
+	size += protoutil.EnumSize(countSelectorField, int32(s.clause))
+	size += protoutil.StringSize(attributeSelectorField, s.attribute)
+	size += protoutil.StringSize(filterSelectorField, s.filter)
 
 	return size
+}
+
+func (s *Selector) Unmarshal(data []byte) error {
+	m := new(netmap.Selector)
+	if err := proto.Unmarshal(data, m); err != nil {
+		return err
+	}
+
+	*s = *SelectorFromGRPCMessage(m)
+
+	return nil
 }
 
 func (r *Replica) StableMarshal(buf []byte) ([]byte, error) {
@@ -178,14 +202,14 @@ func (r *Replica) StableMarshal(buf []byte) ([]byte, error) {
 		err       error
 	)
 
-	n, err = proto.UInt32Marshal(countReplicaField, buf[offset:], r.count)
+	n, err = protoutil.UInt32Marshal(countReplicaField, buf[offset:], r.count)
 	if err != nil {
 		return nil, err
 	}
 
 	offset += n
 
-	n, err = proto.StringMarshal(selectorReplicaField, buf[offset:], r.selector)
+	n, err = protoutil.StringMarshal(selectorReplicaField, buf[offset:], r.selector)
 	if err != nil {
 		return nil, err
 	}
@@ -194,10 +218,21 @@ func (r *Replica) StableMarshal(buf []byte) ([]byte, error) {
 }
 
 func (r *Replica) StableSize() (size int) {
-	size += proto.UInt32Size(countReplicaField, r.count)
-	size += proto.StringSize(selectorReplicaField, r.selector)
+	size += protoutil.UInt32Size(countReplicaField, r.count)
+	size += protoutil.StringSize(selectorReplicaField, r.selector)
 
 	return size
+}
+
+func (r *Replica) Unmarshal(data []byte) error {
+	m := new(netmap.Replica)
+	if err := proto.Unmarshal(data, m); err != nil {
+		return err
+	}
+
+	*r = *ReplicaFromGRPCMessage(m)
+
+	return nil
 }
 
 func (p *PlacementPolicy) StableMarshal(buf []byte) ([]byte, error) {
@@ -215,7 +250,7 @@ func (p *PlacementPolicy) StableMarshal(buf []byte) ([]byte, error) {
 	)
 
 	for i := range p.replicas {
-		n, err = proto.NestedStructureMarshal(replicasPolicyField, buf[offset:], p.replicas[i])
+		n, err = protoutil.NestedStructureMarshal(replicasPolicyField, buf[offset:], p.replicas[i])
 		if err != nil {
 			return nil, err
 		}
@@ -223,7 +258,7 @@ func (p *PlacementPolicy) StableMarshal(buf []byte) ([]byte, error) {
 		offset += n
 	}
 
-	n, err = proto.UInt32Marshal(backupPolicyField, buf[offset:], p.backupFactor)
+	n, err = protoutil.UInt32Marshal(backupPolicyField, buf[offset:], p.backupFactor)
 	if err != nil {
 		return nil, err
 	}
@@ -231,7 +266,7 @@ func (p *PlacementPolicy) StableMarshal(buf []byte) ([]byte, error) {
 	offset += n
 
 	for i := range p.selectors {
-		n, err = proto.NestedStructureMarshal(selectorsPolicyField, buf[offset:], p.selectors[i])
+		n, err = protoutil.NestedStructureMarshal(selectorsPolicyField, buf[offset:], p.selectors[i])
 		if err != nil {
 			return nil, err
 		}
@@ -240,7 +275,7 @@ func (p *PlacementPolicy) StableMarshal(buf []byte) ([]byte, error) {
 	}
 
 	for i := range p.filters {
-		n, err = proto.NestedStructureMarshal(filtersPolicyField, buf[offset:], p.filters[i])
+		n, err = protoutil.NestedStructureMarshal(filtersPolicyField, buf[offset:], p.filters[i])
 		if err != nil {
 			return nil, err
 		}
@@ -253,20 +288,31 @@ func (p *PlacementPolicy) StableMarshal(buf []byte) ([]byte, error) {
 
 func (p *PlacementPolicy) StableSize() (size int) {
 	for i := range p.replicas {
-		size += proto.NestedStructureSize(replicasPolicyField, p.replicas[i])
+		size += protoutil.NestedStructureSize(replicasPolicyField, p.replicas[i])
 	}
 
-	size += proto.UInt32Size(backupPolicyField, p.backupFactor)
+	size += protoutil.UInt32Size(backupPolicyField, p.backupFactor)
 
 	for i := range p.selectors {
-		size += proto.NestedStructureSize(selectorsPolicyField, p.selectors[i])
+		size += protoutil.NestedStructureSize(selectorsPolicyField, p.selectors[i])
 	}
 
 	for i := range p.filters {
-		size += proto.NestedStructureSize(filtersPolicyField, p.filters[i])
+		size += protoutil.NestedStructureSize(filtersPolicyField, p.filters[i])
 	}
 
 	return size
+}
+
+func (p *PlacementPolicy) Unmarshal(data []byte) error {
+	m := new(netmap.PlacementPolicy)
+	if err := proto.Unmarshal(data, m); err != nil {
+		return err
+	}
+
+	*p = *PlacementPolicyFromGRPCMessage(m)
+
+	return nil
 }
 
 func (a *Attribute) StableMarshal(buf []byte) ([]byte, error) {
@@ -283,14 +329,14 @@ func (a *Attribute) StableMarshal(buf []byte) ([]byte, error) {
 		err       error
 	)
 
-	n, err = proto.StringMarshal(keyAttributeField, buf[offset:], a.key)
+	n, err = protoutil.StringMarshal(keyAttributeField, buf[offset:], a.key)
 	if err != nil {
 		return nil, err
 	}
 
 	offset += n
 
-	n, err = proto.StringMarshal(valueAttributeField, buf[offset:], a.value)
+	n, err = protoutil.StringMarshal(valueAttributeField, buf[offset:], a.value)
 	if err != nil {
 		return nil, err
 	}
@@ -298,7 +344,7 @@ func (a *Attribute) StableMarshal(buf []byte) ([]byte, error) {
 	offset += n
 
 	for i := range a.parents {
-		n, err = proto.StringMarshal(parentsAttributeField, buf[offset:], a.parents[i])
+		n, err = protoutil.StringMarshal(parentsAttributeField, buf[offset:], a.parents[i])
 		if err != nil {
 			return nil, err
 		}
@@ -314,14 +360,25 @@ func (a *Attribute) StableSize() (size int) {
 		return 0
 	}
 
-	size += proto.StringSize(keyAttributeField, a.key)
-	size += proto.StringSize(valueAttributeField, a.value)
+	size += protoutil.StringSize(keyAttributeField, a.key)
+	size += protoutil.StringSize(valueAttributeField, a.value)
 
 	for i := range a.parents {
-		size += proto.StringSize(parentsAttributeField, a.parents[i])
+		size += protoutil.StringSize(parentsAttributeField, a.parents[i])
 	}
 
 	return size
+}
+
+func (a *Attribute) Unmarshal(data []byte) error {
+	m := new(netmap.NodeInfo_Attribute)
+	if err := proto.Unmarshal(data, m); err != nil {
+		return err
+	}
+
+	*a = *AttributeFromGRPCMessage(m)
+
+	return nil
 }
 
 func (ni *NodeInfo) StableMarshal(buf []byte) ([]byte, error) {
@@ -338,14 +395,14 @@ func (ni *NodeInfo) StableMarshal(buf []byte) ([]byte, error) {
 		err       error
 	)
 
-	n, err = proto.BytesMarshal(keyNodeInfoField, buf[offset:], ni.publicKey)
+	n, err = protoutil.BytesMarshal(keyNodeInfoField, buf[offset:], ni.publicKey)
 	if err != nil {
 		return nil, err
 	}
 
 	offset += n
 
-	n, err = proto.StringMarshal(addressNodeInfoField, buf[offset:], ni.address)
+	n, err = protoutil.StringMarshal(addressNodeInfoField, buf[offset:], ni.address)
 	if err != nil {
 		return nil, err
 	}
@@ -353,7 +410,7 @@ func (ni *NodeInfo) StableMarshal(buf []byte) ([]byte, error) {
 	offset += n
 
 	for i := range ni.attributes {
-		n, err = proto.NestedStructureMarshal(attributesNodeInfoField, buf[offset:], ni.attributes[i])
+		n, err = protoutil.NestedStructureMarshal(attributesNodeInfoField, buf[offset:], ni.attributes[i])
 		if err != nil {
 			return nil, err
 		}
@@ -361,7 +418,7 @@ func (ni *NodeInfo) StableMarshal(buf []byte) ([]byte, error) {
 		offset += n
 	}
 
-	n, err = proto.EnumMarshal(stateNodeInfoField, buf[offset:], int32(ni.state))
+	n, err = protoutil.EnumMarshal(stateNodeInfoField, buf[offset:], int32(ni.state))
 	if err != nil {
 		return nil, err
 	}
@@ -374,15 +431,26 @@ func (ni *NodeInfo) StableSize() (size int) {
 		return 0
 	}
 
-	size += proto.BytesSize(keyNodeInfoField, ni.publicKey)
-	size += proto.StringSize(addressNodeInfoField, ni.address)
+	size += protoutil.BytesSize(keyNodeInfoField, ni.publicKey)
+	size += protoutil.StringSize(addressNodeInfoField, ni.address)
 	for i := range ni.attributes {
-		size += proto.NestedStructureSize(attributesNodeInfoField, ni.attributes[i])
+		size += protoutil.NestedStructureSize(attributesNodeInfoField, ni.attributes[i])
 	}
 
-	size += proto.EnumSize(stateNodeInfoField, int32(ni.state))
+	size += protoutil.EnumSize(stateNodeInfoField, int32(ni.state))
 
 	return size
+}
+
+func (ni *NodeInfo) Unmarshal(data []byte) error {
+	m := new(netmap.NodeInfo)
+	if err := proto.Unmarshal(data, m); err != nil {
+		return err
+	}
+
+	*ni = *NodeInfoFromGRPCMessage(m)
+
+	return nil
 }
 
 func (l *LocalNodeInfoRequestBody) StableMarshal(buf []byte) ([]byte, error) {
@@ -407,14 +475,14 @@ func (l *LocalNodeInfoResponseBody) StableMarshal(buf []byte) ([]byte, error) {
 		err       error
 	)
 
-	n, err = proto.NestedStructureMarshal(versionInfoResponseBodyField, buf[offset:], l.version)
+	n, err = protoutil.NestedStructureMarshal(versionInfoResponseBodyField, buf[offset:], l.version)
 	if err != nil {
 		return nil, err
 	}
 
 	offset += n
 
-	_, err = proto.NestedStructureMarshal(nodeInfoResponseBodyField, buf[offset:], l.nodeInfo)
+	_, err = protoutil.NestedStructureMarshal(nodeInfoResponseBodyField, buf[offset:], l.nodeInfo)
 	if err != nil {
 		return nil, err
 	}
@@ -427,8 +495,8 @@ func (l *LocalNodeInfoResponseBody) StableSize() (size int) {
 		return 0
 	}
 
-	size += proto.NestedStructureSize(versionInfoResponseBodyField, l.version)
-	size += proto.NestedStructureSize(nodeInfoResponseBodyField, l.nodeInfo)
+	size += protoutil.NestedStructureSize(versionInfoResponseBodyField, l.version)
+	size += protoutil.NestedStructureSize(nodeInfoResponseBodyField, l.nodeInfo)
 
 	return size
 }

--- a/v2/netmap/marshal_test.go
+++ b/v2/netmap/marshal_test.go
@@ -13,96 +13,84 @@ import (
 
 func TestAttribute_StableMarshal(t *testing.T) {
 	from := generateAttribute("key", "value")
-	transport := new(grpc.NodeInfo_Attribute)
 
 	t.Run("non empty", func(t *testing.T) {
 		wire, err := from.StableMarshal(nil)
 		require.NoError(t, err)
 
-		err = goproto.Unmarshal(wire, transport)
-		require.NoError(t, err)
+		to := new(netmap.Attribute)
+		require.NoError(t, to.Unmarshal(wire))
 
-		to := netmap.AttributeFromGRPCMessage(transport)
 		require.Equal(t, from, to)
 	})
 }
 
 func TestNodeInfo_StableMarshal(t *testing.T) {
 	from := generateNodeInfo("publicKey", "/multi/addr", 10)
-	transport := new(grpc.NodeInfo)
 
 	t.Run("non empty", func(t *testing.T) {
 		wire, err := from.StableMarshal(nil)
 		require.NoError(t, err)
 
-		err = goproto.Unmarshal(wire, transport)
-		require.NoError(t, err)
+		to := new(netmap.NodeInfo)
+		require.NoError(t, to.Unmarshal(wire))
 
-		to := netmap.NodeInfoFromGRPCMessage(transport)
 		require.Equal(t, from, to)
 	})
 }
 
 func TestFilter_StableMarshal(t *testing.T) {
 	from := generateFilter("key", "value", false)
-	transport := new(grpc.Filter)
 
 	t.Run("non empty", func(t *testing.T) {
 		wire, err := from.StableMarshal(nil)
 		require.NoError(t, err)
 
-		err = goproto.Unmarshal(wire, transport)
-		require.NoError(t, err)
+		to := new(netmap.Filter)
+		require.NoError(t, to.Unmarshal(wire))
 
-		to := netmap.FilterFromGRPCMessage(transport)
 		require.Equal(t, from, to)
 	})
 }
 
 func TestSelector_StableMarshal(t *testing.T) {
 	from := generateSelector("name")
-	transport := new(grpc.Selector)
 
 	t.Run("non empty", func(t *testing.T) {
 		wire, err := from.StableMarshal(nil)
 		require.NoError(t, err)
 
-		err = goproto.Unmarshal(wire, transport)
-		require.NoError(t, err)
+		to := new(netmap.Selector)
+		require.NoError(t, to.Unmarshal(wire))
 
-		to := netmap.SelectorFromGRPCMessage(transport)
 		require.Equal(t, from, to)
 	})
 }
 
 func TestReplica_StableMarshal(t *testing.T) {
 	from := generateReplica("selector")
-	transport := new(grpc.Replica)
 
 	t.Run("non empty", func(t *testing.T) {
 		wire, err := from.StableMarshal(nil)
 		require.NoError(t, err)
 
-		err = goproto.Unmarshal(wire, transport)
-		require.NoError(t, err)
+		to := new(netmap.Replica)
+		require.NoError(t, to.Unmarshal(wire))
 
-		to := netmap.ReplicaFromGRPCMessage(transport)
 		require.Equal(t, from, to)
 	})
 }
 
 func TestPlacementPolicy_StableMarshal(t *testing.T) {
 	from := generatePolicy(3)
-	transport := new(grpc.PlacementPolicy)
 
 	t.Run("non empty", func(t *testing.T) {
 		wire, err := from.StableMarshal(nil)
 		require.NoError(t, err)
 
-		err = goproto.Unmarshal(wire, transport)
-		require.NoError(t, err)
+		to := new(netmap.PlacementPolicy)
+		require.NoError(t, to.Unmarshal(wire))
 
-		to := netmap.PlacementPolicyFromGRPCMessage(transport)
 		require.Equal(t, from, to)
 	})
 }

--- a/v2/object/json.go
+++ b/v2/object/json.go
@@ -84,3 +84,23 @@ func (h *Header) UnmarshalJSON(data []byte) error {
 
 	return nil
 }
+
+func (h *HeaderWithSignature) MarshalJSON() ([]byte, error) {
+	return protojson.MarshalOptions{
+		EmitUnpopulated: true,
+	}.Marshal(
+		HeaderWithSignatureToGRPCMessage(h),
+	)
+}
+
+func (h *HeaderWithSignature) UnmarshalJSON(data []byte) error {
+	msg := new(object.HeaderWithSignature)
+
+	if err := protojson.Unmarshal(data, msg); err != nil {
+		return err
+	}
+
+	*h = *HeaderWithSignatureFromGRPCMessage(msg)
+
+	return nil
+}

--- a/v2/object/json.go
+++ b/v2/object/json.go
@@ -64,3 +64,23 @@ func (h *SplitHeader) UnmarshalJSON(data []byte) error {
 
 	return nil
 }
+
+func (h *Header) MarshalJSON() ([]byte, error) {
+	return protojson.MarshalOptions{
+		EmitUnpopulated: true,
+	}.Marshal(
+		HeaderToGRPCMessage(h),
+	)
+}
+
+func (h *Header) UnmarshalJSON(data []byte) error {
+	msg := new(object.Header)
+
+	if err := protojson.Unmarshal(data, msg); err != nil {
+		return err
+	}
+
+	*h = *HeaderFromGRPCMessage(msg)
+
+	return nil
+}

--- a/v2/object/json.go
+++ b/v2/object/json.go
@@ -24,3 +24,23 @@ func (h *ShortHeader) UnmarshalJSON(data []byte) error {
 
 	return nil
 }
+
+func (a *Attribute) MarshalJSON() ([]byte, error) {
+	return protojson.MarshalOptions{
+		EmitUnpopulated: true,
+	}.Marshal(
+		AttributeToGRPCMessage(a),
+	)
+}
+
+func (a *Attribute) UnmarshalJSON(data []byte) error {
+	msg := new(object.Header_Attribute)
+
+	if err := protojson.Unmarshal(data, msg); err != nil {
+		return err
+	}
+
+	*a = *AttributeFromGRPCMessage(msg)
+
+	return nil
+}

--- a/v2/object/json.go
+++ b/v2/object/json.go
@@ -104,3 +104,23 @@ func (h *HeaderWithSignature) UnmarshalJSON(data []byte) error {
 
 	return nil
 }
+
+func (o *Object) MarshalJSON() ([]byte, error) {
+	return protojson.MarshalOptions{
+		EmitUnpopulated: true,
+	}.Marshal(
+		ObjectToGRPCMessage(o),
+	)
+}
+
+func (o *Object) UnmarshalJSON(data []byte) error {
+	msg := new(object.Object)
+
+	if err := protojson.Unmarshal(data, msg); err != nil {
+		return err
+	}
+
+	*o = *ObjectFromGRPCMessage(msg)
+
+	return nil
+}

--- a/v2/object/json.go
+++ b/v2/object/json.go
@@ -44,3 +44,23 @@ func (a *Attribute) UnmarshalJSON(data []byte) error {
 
 	return nil
 }
+
+func (h *SplitHeader) MarshalJSON() ([]byte, error) {
+	return protojson.MarshalOptions{
+		EmitUnpopulated: true,
+	}.Marshal(
+		SplitHeaderToGRPCMessage(h),
+	)
+}
+
+func (h *SplitHeader) UnmarshalJSON(data []byte) error {
+	msg := new(object.Header_Split)
+
+	if err := protojson.Unmarshal(data, msg); err != nil {
+		return err
+	}
+
+	*h = *SplitHeaderFromGRPCMessage(msg)
+
+	return nil
+}

--- a/v2/object/json.go
+++ b/v2/object/json.go
@@ -1,0 +1,26 @@
+package object
+
+import (
+	object "github.com/nspcc-dev/neofs-api-go/v2/object/grpc"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+func (h *ShortHeader) MarshalJSON() ([]byte, error) {
+	return protojson.MarshalOptions{
+		EmitUnpopulated: true,
+	}.Marshal(
+		ShortHeaderToGRPCMessage(h),
+	)
+}
+
+func (h *ShortHeader) UnmarshalJSON(data []byte) error {
+	msg := new(object.ShortHeader)
+
+	if err := protojson.Unmarshal(data, msg); err != nil {
+		return err
+	}
+
+	*h = *ShortHeaderFromGRPCMessage(msg)
+
+	return nil
+}

--- a/v2/object/json_test.go
+++ b/v2/object/json_test.go
@@ -54,3 +54,15 @@ func TestHeaderJSON(t *testing.T) {
 
 	require.Equal(t, h, h2)
 }
+
+func TestHeaderWithSignatureJSON(t *testing.T) {
+	h := generateHeaderWithSignature()
+
+	data, err := h.MarshalJSON()
+	require.NoError(t, err)
+
+	h2 := new(object.HeaderWithSignature)
+	require.NoError(t, h2.UnmarshalJSON(data))
+
+	require.Equal(t, h, h2)
+}

--- a/v2/object/json_test.go
+++ b/v2/object/json_test.go
@@ -42,3 +42,15 @@ func TestSplitHeaderJSON(t *testing.T) {
 
 	require.Equal(t, h, h2)
 }
+
+func TestHeaderJSON(t *testing.T) {
+	h := generateHeader(10)
+
+	data, err := h.MarshalJSON()
+	require.NoError(t, err)
+
+	h2 := new(object.Header)
+	require.NoError(t, h2.UnmarshalJSON(data))
+
+	require.Equal(t, h, h2)
+}

--- a/v2/object/json_test.go
+++ b/v2/object/json_test.go
@@ -30,3 +30,15 @@ func TestAttributeJSON(t *testing.T) {
 
 	require.Equal(t, a, a2)
 }
+
+func TestSplitHeaderJSON(t *testing.T) {
+	h := generateSplit("sig")
+
+	data, err := h.MarshalJSON()
+	require.NoError(t, err)
+
+	h2 := new(object.SplitHeader)
+	require.NoError(t, h2.UnmarshalJSON(data))
+
+	require.Equal(t, h, h2)
+}

--- a/v2/object/json_test.go
+++ b/v2/object/json_test.go
@@ -18,3 +18,15 @@ func TestShortHeaderJSON(t *testing.T) {
 
 	require.Equal(t, h, h2)
 }
+
+func TestAttributeJSON(t *testing.T) {
+	a := generateAttribute("key", "value")
+
+	data, err := a.MarshalJSON()
+	require.NoError(t, err)
+
+	a2 := new(object.Attribute)
+	require.NoError(t, a2.UnmarshalJSON(data))
+
+	require.Equal(t, a, a2)
+}

--- a/v2/object/json_test.go
+++ b/v2/object/json_test.go
@@ -1,0 +1,20 @@
+package object_test
+
+import (
+	"testing"
+
+	"github.com/nspcc-dev/neofs-api-go/v2/object"
+	"github.com/stretchr/testify/require"
+)
+
+func TestShortHeaderJSON(t *testing.T) {
+	h := generateShortHeader("id")
+
+	data, err := h.MarshalJSON()
+	require.NoError(t, err)
+
+	h2 := new(object.ShortHeader)
+	require.NoError(t, h2.UnmarshalJSON(data))
+
+	require.Equal(t, h, h2)
+}

--- a/v2/object/json_test.go
+++ b/v2/object/json_test.go
@@ -66,3 +66,15 @@ func TestHeaderWithSignatureJSON(t *testing.T) {
 
 	require.Equal(t, h, h2)
 }
+
+func TestObjectJSON(t *testing.T) {
+	o := generateObject("data")
+
+	data, err := o.MarshalJSON()
+	require.NoError(t, err)
+
+	o2 := new(object.Object)
+	require.NoError(t, o2.UnmarshalJSON(data))
+
+	require.Equal(t, o, o2)
+}

--- a/v2/object/marshal.go
+++ b/v2/object/marshal.go
@@ -422,6 +422,17 @@ func (h *Header) StableSize() (size int) {
 	return size
 }
 
+func (h *Header) Unmarshal(data []byte) error {
+	m := new(object.Header)
+	if err := goproto.Unmarshal(data, m); err != nil {
+		return err
+	}
+
+	*h = *HeaderFromGRPCMessage(m)
+
+	return nil
+}
+
 func (h *HeaderWithSignature) StableMarshal(buf []byte) ([]byte, error) {
 	if h == nil {
 		return []byte{}, nil

--- a/v2/object/marshal.go
+++ b/v2/object/marshal.go
@@ -557,6 +557,17 @@ func (o *Object) StableUnmarshal(data []byte) error {
 	return nil
 }
 
+func (o *Object) Unmarshal(data []byte) error {
+	m := new(object.Object)
+	if err := goproto.Unmarshal(data, m); err != nil {
+		return err
+	}
+
+	*o = *ObjectFromGRPCMessage(m)
+
+	return nil
+}
+
 func (r *GetRequestBody) StableMarshal(buf []byte) ([]byte, error) {
 	if r == nil {
 		return []byte{}, nil

--- a/v2/object/marshal.go
+++ b/v2/object/marshal.go
@@ -162,6 +162,17 @@ func (h *ShortHeader) StableSize() (size int) {
 	return size
 }
 
+func (h *ShortHeader) Unmarshal(data []byte) error {
+	m := new(object.ShortHeader)
+	if err := goproto.Unmarshal(data, m); err != nil {
+		return err
+	}
+
+	*h = *ShortHeaderFromGRPCMessage(m)
+
+	return nil
+}
+
 func (a *Attribute) StableMarshal(buf []byte) ([]byte, error) {
 	if a == nil {
 		return []byte{}, nil

--- a/v2/object/marshal.go
+++ b/v2/object/marshal.go
@@ -213,6 +213,17 @@ func (a *Attribute) StableSize() (size int) {
 	return size
 }
 
+func (a *Attribute) Unmarshal(data []byte) error {
+	m := new(object.Header_Attribute)
+	if err := goproto.Unmarshal(data, m); err != nil {
+		return err
+	}
+
+	*a = *AttributeFromGRPCMessage(m)
+
+	return nil
+}
+
 func (h *SplitHeader) StableMarshal(buf []byte) ([]byte, error) {
 	if h == nil {
 		return []byte{}, nil

--- a/v2/object/marshal.go
+++ b/v2/object/marshal.go
@@ -295,6 +295,17 @@ func (h *SplitHeader) StableSize() (size int) {
 	return size
 }
 
+func (h *SplitHeader) Unmarshal(data []byte) error {
+	m := new(object.Header_Split)
+	if err := goproto.Unmarshal(data, m); err != nil {
+		return err
+	}
+
+	*h = *SplitHeaderFromGRPCMessage(m)
+
+	return nil
+}
+
 func (h *Header) StableMarshal(buf []byte) ([]byte, error) {
 	if h == nil {
 		return []byte{}, nil

--- a/v2/object/marshal.go
+++ b/v2/object/marshal.go
@@ -475,6 +475,17 @@ func (h *HeaderWithSignature) StableSize() (size int) {
 	return size
 }
 
+func (h *HeaderWithSignature) Unmarshal(data []byte) error {
+	m := new(object.HeaderWithSignature)
+	if err := goproto.Unmarshal(data, m); err != nil {
+		return err
+	}
+
+	*h = *HeaderWithSignatureFromGRPCMessage(m)
+
+	return nil
+}
+
 func (o *Object) StableMarshal(buf []byte) ([]byte, error) {
 	if o == nil {
 		return []byte{}, nil

--- a/v2/object/marshal_test.go
+++ b/v2/object/marshal_test.go
@@ -352,6 +352,20 @@ func TestGetRangeHashResponseBody_StableMarshal(t *testing.T) {
 	})
 }
 
+func TestHeaderWithSignature_StableMarshal(t *testing.T) {
+	from := generateHeaderWithSignature()
+
+	t.Run("non empty", func(t *testing.T) {
+		wire, err := from.StableMarshal(nil)
+		require.NoError(t, err)
+
+		to := new(object.HeaderWithSignature)
+		require.NoError(t, to.Unmarshal(wire))
+
+		require.Equal(t, from, to)
+	})
+}
+
 func generateOwner(id string) *refs.OwnerID {
 	owner := new(refs.OwnerID)
 	owner.SetValue([]byte(id))
@@ -582,18 +596,22 @@ func generateHeadResponseBody(flag bool) *object.HeadResponseBody {
 		short.SetShortHeader(generateShortHeader("short id"))
 		part = short
 	} else {
-		hdrWithSig := new(object.HeaderWithSignature)
-		hdrWithSig.SetHeader(generateHeader(30))
-		hdrWithSig.SetSignature(generateSignature("sig", "key"))
-
 		full := new(object.GetHeaderPartFull)
-		full.SetHeaderWithSignature(hdrWithSig)
+		full.SetHeaderWithSignature(generateHeaderWithSignature())
 		part = full
 	}
 
 	req.SetHeaderPart(part)
 
 	return req
+}
+
+func generateHeaderWithSignature() *object.HeaderWithSignature {
+	hdrWithSig := new(object.HeaderWithSignature)
+	hdrWithSig.SetHeader(generateHeader(30))
+	hdrWithSig.SetSignature(generateSignature("sig", "key"))
+
+	return hdrWithSig
 }
 
 func generateFilter(k, v string) *object.SearchFilter {

--- a/v2/object/marshal_test.go
+++ b/v2/object/marshal_test.go
@@ -46,16 +46,13 @@ func TestSplitHeader_StableMarshal(t *testing.T) {
 	hdr := generateHeader(123)
 	from.SetParentHeader(hdr)
 
-	transport := new(grpc.Header_Split)
-
 	t.Run("non empty", func(t *testing.T) {
 		wire, err := from.StableMarshal(nil)
 		require.NoError(t, err)
 
-		err = goproto.Unmarshal(wire, transport)
-		require.NoError(t, err)
+		to := new(object.SplitHeader)
+		require.NoError(t, to.Unmarshal(wire))
 
-		to := object.SplitHeaderFromGRPCMessage(transport)
 		require.Equal(t, from, to)
 	})
 }

--- a/v2/object/marshal_test.go
+++ b/v2/object/marshal_test.go
@@ -65,16 +65,13 @@ func TestHeader_StableMarshal(t *testing.T) {
 	from := generateHeader(500)
 	from.SetSplit(split)
 
-	transport := new(grpc.Header)
-
 	t.Run("non empty", func(t *testing.T) {
 		wire, err := from.StableMarshal(nil)
 		require.NoError(t, err)
 
-		err = goproto.Unmarshal(wire, transport)
-		require.NoError(t, err)
+		to := new(object.Header)
+		require.NoError(t, to.Unmarshal(wire))
 
-		to := object.HeaderFromGRPCMessage(transport)
 		require.Equal(t, from, to)
 	})
 }

--- a/v2/object/marshal_test.go
+++ b/v2/object/marshal_test.go
@@ -15,16 +15,14 @@ import (
 
 func TestShortHeader_StableMarshal(t *testing.T) {
 	hdrFrom := generateShortHeader("Owner ID")
-	transport := new(grpc.ShortHeader)
 
 	t.Run("non empty", func(t *testing.T) {
 		wire, err := hdrFrom.StableMarshal(nil)
 		require.NoError(t, err)
 
-		err = goproto.Unmarshal(wire, transport)
-		require.NoError(t, err)
+		hdrTo := new(object.ShortHeader)
+		require.NoError(t, hdrTo.Unmarshal(wire))
 
-		hdrTo := object.ShortHeaderFromGRPCMessage(transport)
 		require.Equal(t, hdrFrom, hdrTo)
 	})
 }

--- a/v2/object/marshal_test.go
+++ b/v2/object/marshal_test.go
@@ -29,16 +29,14 @@ func TestShortHeader_StableMarshal(t *testing.T) {
 
 func TestAttribute_StableMarshal(t *testing.T) {
 	from := generateAttribute("Key", "Value")
-	transport := new(grpc.Header_Attribute)
 
 	t.Run("non empty", func(t *testing.T) {
 		wire, err := from.StableMarshal(nil)
 		require.NoError(t, err)
 
-		err = goproto.Unmarshal(wire, transport)
-		require.NoError(t, err)
+		to := new(object.Attribute)
+		require.NoError(t, to.Unmarshal(wire))
 
-		to := object.AttributeFromGRPCMessage(transport)
 		require.Equal(t, from, to)
 	})
 }

--- a/v2/object/marshal_test.go
+++ b/v2/object/marshal_test.go
@@ -78,16 +78,14 @@ func TestHeader_StableMarshal(t *testing.T) {
 
 func TestObject_StableMarshal(t *testing.T) {
 	from := generateObject("Payload")
-	transport := new(grpc.Object)
 
 	t.Run("non empty", func(t *testing.T) {
 		wire, err := from.StableMarshal(nil)
 		require.NoError(t, err)
 
-		err = goproto.Unmarshal(wire, transport)
-		require.NoError(t, err)
+		to := new(object.Object)
+		require.NoError(t, to.Unmarshal(wire))
 
-		to := object.ObjectFromGRPCMessage(transport)
 		require.Equal(t, from, to)
 	})
 }

--- a/v2/refs/json.go
+++ b/v2/refs/json.go
@@ -44,3 +44,23 @@ func (o *ObjectID) UnmarshalJSON(data []byte) error {
 
 	return nil
 }
+
+func (c *ContainerID) MarshalJSON() ([]byte, error) {
+	return protojson.MarshalOptions{
+		EmitUnpopulated: true,
+	}.Marshal(
+		ContainerIDToGRPCMessage(c),
+	)
+}
+
+func (c *ContainerID) UnmarshalJSON(data []byte) error {
+	msg := new(refs.ContainerID)
+
+	if err := protojson.Unmarshal(data, msg); err != nil {
+		return err
+	}
+
+	*c = *ContainerIDFromGRPCMessage(msg)
+
+	return nil
+}

--- a/v2/refs/json.go
+++ b/v2/refs/json.go
@@ -64,3 +64,23 @@ func (c *ContainerID) UnmarshalJSON(data []byte) error {
 
 	return nil
 }
+
+func (o *OwnerID) MarshalJSON() ([]byte, error) {
+	return protojson.MarshalOptions{
+		EmitUnpopulated: true,
+	}.Marshal(
+		OwnerIDToGRPCMessage(o),
+	)
+}
+
+func (o *OwnerID) UnmarshalJSON(data []byte) error {
+	msg := new(refs.OwnerID)
+
+	if err := protojson.Unmarshal(data, msg); err != nil {
+		return err
+	}
+
+	*o = *OwnerIDFromGRPCMessage(msg)
+
+	return nil
+}

--- a/v2/refs/json.go
+++ b/v2/refs/json.go
@@ -124,3 +124,23 @@ func (s *Signature) UnmarshalJSON(data []byte) error {
 
 	return nil
 }
+
+func (c *Checksum) MarshalJSON() ([]byte, error) {
+	return protojson.MarshalOptions{
+		EmitUnpopulated: true,
+	}.Marshal(
+		ChecksumToGRPCMessage(c),
+	)
+}
+
+func (c *Checksum) UnmarshalJSON(data []byte) error {
+	msg := new(refs.Checksum)
+
+	if err := protojson.Unmarshal(data, msg); err != nil {
+		return err
+	}
+
+	*c = *ChecksumFromGRPCMessage(msg)
+
+	return nil
+}

--- a/v2/refs/json.go
+++ b/v2/refs/json.go
@@ -1,0 +1,26 @@
+package refs
+
+import (
+	refs "github.com/nspcc-dev/neofs-api-go/v2/refs/grpc"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+func (a *Address) MarshalJSON() ([]byte, error) {
+	return protojson.MarshalOptions{
+		EmitUnpopulated: true,
+	}.Marshal(
+		AddressToGRPCMessage(a),
+	)
+}
+
+func (a *Address) UnmarshalJSON(data []byte) error {
+	msg := new(refs.Address)
+
+	if err := protojson.Unmarshal(data, msg); err != nil {
+		return err
+	}
+
+	*a = *AddressFromGRPCMessage(msg)
+
+	return nil
+}

--- a/v2/refs/json.go
+++ b/v2/refs/json.go
@@ -24,3 +24,23 @@ func (a *Address) UnmarshalJSON(data []byte) error {
 
 	return nil
 }
+
+func (o *ObjectID) MarshalJSON() ([]byte, error) {
+	return protojson.MarshalOptions{
+		EmitUnpopulated: true,
+	}.Marshal(
+		ObjectIDToGRPCMessage(o),
+	)
+}
+
+func (o *ObjectID) UnmarshalJSON(data []byte) error {
+	msg := new(refs.ObjectID)
+
+	if err := protojson.Unmarshal(data, msg); err != nil {
+		return err
+	}
+
+	*o = *ObjectIDFromGRPCMessage(msg)
+
+	return nil
+}

--- a/v2/refs/json.go
+++ b/v2/refs/json.go
@@ -104,3 +104,23 @@ func (v *Version) UnmarshalJSON(data []byte) error {
 
 	return nil
 }
+
+func (s *Signature) MarshalJSON() ([]byte, error) {
+	return protojson.MarshalOptions{
+		EmitUnpopulated: true,
+	}.Marshal(
+		SignatureToGRPCMessage(s),
+	)
+}
+
+func (s *Signature) UnmarshalJSON(data []byte) error {
+	msg := new(refs.Signature)
+
+	if err := protojson.Unmarshal(data, msg); err != nil {
+		return err
+	}
+
+	*s = *SignatureFromGRPCMessage(msg)
+
+	return nil
+}

--- a/v2/refs/json.go
+++ b/v2/refs/json.go
@@ -84,3 +84,23 @@ func (o *OwnerID) UnmarshalJSON(data []byte) error {
 
 	return nil
 }
+
+func (v *Version) MarshalJSON() ([]byte, error) {
+	return protojson.MarshalOptions{
+		EmitUnpopulated: true,
+	}.Marshal(
+		VersionToGRPCMessage(v),
+	)
+}
+
+func (v *Version) UnmarshalJSON(data []byte) error {
+	msg := new(refs.Version)
+
+	if err := protojson.Unmarshal(data, msg); err != nil {
+		return err
+	}
+
+	*v = *VersionFromGRPCMessage(msg)
+
+	return nil
+}

--- a/v2/refs/json_test.go
+++ b/v2/refs/json_test.go
@@ -18,3 +18,16 @@ func TestAddressJSON(t *testing.T) {
 
 	require.Equal(t, a, a2)
 }
+
+func TestObjectIDJSON(t *testing.T) {
+	o := new(refs.ObjectID)
+	o.SetValue([]byte{1})
+
+	data, err := o.MarshalJSON()
+	require.NoError(t, err)
+
+	o2 := new(refs.ObjectID)
+	require.NoError(t, o2.UnmarshalJSON(data))
+
+	require.Equal(t, o, o2)
+}

--- a/v2/refs/json_test.go
+++ b/v2/refs/json_test.go
@@ -1,0 +1,20 @@
+package refs_test
+
+import (
+	"testing"
+
+	"github.com/nspcc-dev/neofs-api-go/v2/refs"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAddressJSON(t *testing.T) {
+	a := generateAddress([]byte{1}, []byte{2})
+
+	data, err := a.MarshalJSON()
+	require.NoError(t, err)
+
+	a2 := new(refs.Address)
+	require.NoError(t, a2.UnmarshalJSON(data))
+
+	require.Equal(t, a, a2)
+}

--- a/v2/refs/json_test.go
+++ b/v2/refs/json_test.go
@@ -81,3 +81,17 @@ func TestSignatureSON(t *testing.T) {
 
 	require.Equal(t, s, s2)
 }
+
+func TestChecksumJSON(t *testing.T) {
+	cs := new(refs.Checksum)
+	cs.SetType(refs.SHA256)
+	cs.SetSum([]byte{1, 2, 3})
+
+	data, err := cs.MarshalJSON()
+	require.NoError(t, err)
+
+	cs2 := new(refs.Checksum)
+	require.NoError(t, cs2.UnmarshalJSON(data))
+
+	require.Equal(t, cs, cs2)
+}

--- a/v2/refs/json_test.go
+++ b/v2/refs/json_test.go
@@ -44,3 +44,16 @@ func TestContainerIDJSON(t *testing.T) {
 
 	require.Equal(t, cid, cid2)
 }
+
+func TestOwnerIDJSON(t *testing.T) {
+	o := new(refs.OwnerID)
+	o.SetValue([]byte{1})
+
+	data, err := o.MarshalJSON()
+	require.NoError(t, err)
+
+	o2 := new(refs.OwnerID)
+	require.NoError(t, o2.UnmarshalJSON(data))
+
+	require.Equal(t, o, o2)
+}

--- a/v2/refs/json_test.go
+++ b/v2/refs/json_test.go
@@ -69,3 +69,15 @@ func TestVersionSON(t *testing.T) {
 
 	require.Equal(t, v, v2)
 }
+
+func TestSignatureSON(t *testing.T) {
+	s := generateSignature("key", "sig")
+
+	data, err := s.MarshalJSON()
+	require.NoError(t, err)
+
+	s2 := new(refs.Signature)
+	require.NoError(t, s2.UnmarshalJSON(data))
+
+	require.Equal(t, s, s2)
+}

--- a/v2/refs/json_test.go
+++ b/v2/refs/json_test.go
@@ -31,3 +31,16 @@ func TestObjectIDJSON(t *testing.T) {
 
 	require.Equal(t, o, o2)
 }
+
+func TestContainerIDJSON(t *testing.T) {
+	cid := new(refs.ContainerID)
+	cid.SetValue([]byte{1})
+
+	data, err := cid.MarshalJSON()
+	require.NoError(t, err)
+
+	cid2 := new(refs.ContainerID)
+	require.NoError(t, cid2.UnmarshalJSON(data))
+
+	require.Equal(t, cid, cid2)
+}

--- a/v2/refs/json_test.go
+++ b/v2/refs/json_test.go
@@ -57,3 +57,15 @@ func TestOwnerIDJSON(t *testing.T) {
 
 	require.Equal(t, o, o2)
 }
+
+func TestVersionSON(t *testing.T) {
+	v := generateVersion(1, 2)
+
+	data, err := v.MarshalJSON()
+	require.NoError(t, err)
+
+	v2 := new(refs.Version)
+	require.NoError(t, v2.UnmarshalJSON(data))
+
+	require.Equal(t, v, v2)
+}

--- a/v2/refs/marshal.go
+++ b/v2/refs/marshal.go
@@ -226,6 +226,17 @@ func (c *Checksum) StableSize() (size int) {
 	return size
 }
 
+func (c *Checksum) Unmarshal(data []byte) error {
+	m := new(refs.Checksum)
+	if err := goproto.Unmarshal(data, m); err != nil {
+		return err
+	}
+
+	*c = *ChecksumFromGRPCMessage(m)
+
+	return nil
+}
+
 func (s *Signature) StableMarshal(buf []byte) ([]byte, error) {
 	if s == nil {
 		return []byte{}, nil

--- a/v2/refs/marshal.go
+++ b/v2/refs/marshal.go
@@ -76,6 +76,17 @@ func (c *ContainerID) StableSize() int {
 	return proto.BytesSize(containerIDValField, c.val)
 }
 
+func (c *ContainerID) Unmarshal(data []byte) error {
+	m := new(refs.ContainerID)
+	if err := goproto.Unmarshal(data, m); err != nil {
+		return err
+	}
+
+	*c = *ContainerIDFromGRPCMessage(m)
+
+	return nil
+}
+
 func (o *ObjectID) StableMarshal(buf []byte) ([]byte, error) {
 	if o == nil {
 		return []byte{}, nil

--- a/v2/refs/marshal.go
+++ b/v2/refs/marshal.go
@@ -51,6 +51,17 @@ func (o *OwnerID) StableSize() int {
 	return proto.BytesSize(ownerIDValField, o.val)
 }
 
+func (o *OwnerID) Unmarshal(data []byte) error {
+	m := new(refs.OwnerID)
+	if err := goproto.Unmarshal(data, m); err != nil {
+		return err
+	}
+
+	*o = *OwnerIDFromGRPCMessage(m)
+
+	return nil
+}
+
 func (c *ContainerID) StableMarshal(buf []byte) ([]byte, error) {
 	if c == nil {
 		return []byte{}, nil

--- a/v2/refs/marshal.go
+++ b/v2/refs/marshal.go
@@ -142,11 +142,7 @@ func (a *Address) StableSize() (size int) {
 	return size
 }
 
-func (a *Address) StableUnmarshal(data []byte) error {
-	if a == nil {
-		return nil
-	}
-
+func (a *Address) Unmarshal(data []byte) error {
 	addrGRPC := new(refs.Address)
 	if err := goproto.Unmarshal(data, addrGRPC); err != nil {
 		return err

--- a/v2/refs/marshal.go
+++ b/v2/refs/marshal.go
@@ -305,3 +305,14 @@ func (v *Version) StableSize() (size int) {
 
 	return size
 }
+
+func (v *Version) Unmarshal(data []byte) error {
+	m := new(refs.Version)
+	if err := goproto.Unmarshal(data, m); err != nil {
+		return err
+	}
+
+	*v = *VersionFromGRPCMessage(m)
+
+	return nil
+}

--- a/v2/refs/marshal.go
+++ b/v2/refs/marshal.go
@@ -266,6 +266,17 @@ func (s *Signature) StableSize() (size int) {
 	return size
 }
 
+func (s *Signature) Unmarshal(data []byte) error {
+	m := new(refs.Signature)
+	if err := goproto.Unmarshal(data, m); err != nil {
+		return err
+	}
+
+	*s = *SignatureFromGRPCMessage(m)
+
+	return nil
+}
+
 func (v *Version) StableMarshal(buf []byte) ([]byte, error) {
 	if v == nil {
 		return []byte{}, nil

--- a/v2/refs/marshal.go
+++ b/v2/refs/marshal.go
@@ -101,6 +101,17 @@ func (o *ObjectID) StableSize() int {
 	return proto.BytesSize(objectIDValField, o.val)
 }
 
+func (o *ObjectID) Unmarshal(data []byte) error {
+	m := new(refs.ObjectID)
+	if err := goproto.Unmarshal(data, m); err != nil {
+		return err
+	}
+
+	*o = *ObjectIDFromGRPCMessage(m)
+
+	return nil
+}
+
 func (a *Address) StableMarshal(buf []byte) ([]byte, error) {
 	if a == nil {
 		return []byte{}, nil

--- a/v2/refs/marshal_test.go
+++ b/v2/refs/marshal_test.go
@@ -95,16 +95,14 @@ func TestChecksum_StableMarshal(t *testing.T) {
 
 func TestSignature_StableMarshal(t *testing.T) {
 	signatureFrom := generateSignature("Public Key", "Signature")
-	transport := new(grpc.Signature)
 
 	t.Run("non empty", func(t *testing.T) {
 		wire, err := signatureFrom.StableMarshal(nil)
 		require.NoError(t, err)
 
-		err = goproto.Unmarshal(wire, transport)
-		require.NoError(t, err)
+		signatureTo := new(refs.Signature)
+		require.NoError(t, signatureTo.Unmarshal(wire))
 
-		signatureTo := refs.SignatureFromGRPCMessage(transport)
 		require.Equal(t, signatureFrom, signatureTo)
 	})
 }

--- a/v2/refs/marshal_test.go
+++ b/v2/refs/marshal_test.go
@@ -111,16 +111,14 @@ func TestSignature_StableMarshal(t *testing.T) {
 
 func TestVersion_StableMarshal(t *testing.T) {
 	versionFrom := generateVersion(2, 0)
-	transport := new(grpc.Version)
 
 	t.Run("non empty", func(t *testing.T) {
 		wire, err := versionFrom.StableMarshal(nil)
 		require.NoError(t, err)
 
-		err = goproto.Unmarshal(wire, transport)
-		require.NoError(t, err)
+		versionTo := new(refs.Version)
+		require.NoError(t, versionTo.Unmarshal(wire))
 
-		versionTo := refs.VersionFromGRPCMessage(transport)
 		require.Equal(t, versionFrom, versionTo)
 	})
 }

--- a/v2/refs/marshal_test.go
+++ b/v2/refs/marshal_test.go
@@ -4,9 +4,7 @@ import (
 	"testing"
 
 	"github.com/nspcc-dev/neofs-api-go/v2/refs"
-	grpc "github.com/nspcc-dev/neofs-api-go/v2/refs/grpc"
 	"github.com/stretchr/testify/require"
-	goproto "google.golang.org/protobuf/proto"
 )
 
 func TestOwnerID_StableMarshal(t *testing.T) {
@@ -76,7 +74,6 @@ func TestAddress_StableMarshal(t *testing.T) {
 
 func TestChecksum_StableMarshal(t *testing.T) {
 	checksumFrom := new(refs.Checksum)
-	transport := new(grpc.Checksum)
 
 	t.Run("non empty", func(t *testing.T) {
 		checksumFrom.SetType(refs.TillichZemor)
@@ -85,10 +82,9 @@ func TestChecksum_StableMarshal(t *testing.T) {
 		wire, err := checksumFrom.StableMarshal(nil)
 		require.NoError(t, err)
 
-		err = goproto.Unmarshal(wire, transport)
-		require.NoError(t, err)
+		checksumTo := new(refs.Checksum)
+		require.NoError(t, checksumTo.Unmarshal(wire))
 
-		checksumTo := refs.ChecksumFromGRPCMessage(transport)
 		require.Equal(t, checksumFrom, checksumTo)
 	})
 }

--- a/v2/refs/marshal_test.go
+++ b/v2/refs/marshal_test.go
@@ -11,7 +11,6 @@ import (
 
 func TestOwnerID_StableMarshal(t *testing.T) {
 	ownerFrom := new(refs.OwnerID)
-	ownerTransport := new(grpc.OwnerID)
 
 	t.Run("non empty", func(t *testing.T) {
 		ownerFrom.SetValue([]byte("Owner ID"))
@@ -19,10 +18,9 @@ func TestOwnerID_StableMarshal(t *testing.T) {
 		wire, err := ownerFrom.StableMarshal(nil)
 		require.NoError(t, err)
 
-		err = goproto.Unmarshal(wire, ownerTransport)
-		require.NoError(t, err)
+		ownerTo := new(refs.OwnerID)
+		require.NoError(t, ownerTo.Unmarshal(wire))
 
-		ownerTo := refs.OwnerIDFromGRPCMessage(ownerTransport)
 		require.Equal(t, ownerFrom, ownerTo)
 	})
 }

--- a/v2/refs/marshal_test.go
+++ b/v2/refs/marshal_test.go
@@ -69,16 +69,13 @@ func TestAddress_StableMarshal(t *testing.T) {
 
 	addressFrom := generateAddress(cid, oid)
 
-	addressTransport := new(grpc.Address)
-
 	t.Run("non empty", func(t *testing.T) {
 		wire, err := addressFrom.StableMarshal(nil)
 		require.NoError(t, err)
 
-		err = goproto.Unmarshal(wire, addressTransport)
-		require.NoError(t, err)
+		addressTo := new(refs.Address)
+		require.NoError(t, addressTo.Unmarshal(wire))
 
-		addressTo := refs.AddressFromGRPCMessage(addressTransport)
 		require.Equal(t, addressFrom, addressTo)
 	})
 }
@@ -160,16 +157,4 @@ func generateAddress(bCid, bOid []byte) *refs.Address {
 	oid.SetValue(bOid)
 
 	return addr
-}
-
-func TestAddress_StableUnmarshal(t *testing.T) {
-	addr := generateAddress([]byte("container id"), []byte("object id"))
-
-	data, err := addr.StableMarshal(nil)
-	require.NoError(t, err)
-
-	addr2 := new(refs.Address)
-	require.NoError(t, addr2.StableUnmarshal(data))
-
-	require.Equal(t, addr, addr2)
 }

--- a/v2/refs/marshal_test.go
+++ b/v2/refs/marshal_test.go
@@ -29,7 +29,6 @@ func TestOwnerID_StableMarshal(t *testing.T) {
 
 func TestContainerID_StableMarshal(t *testing.T) {
 	cnrFrom := new(refs.ContainerID)
-	cnrTransport := new(grpc.ContainerID)
 
 	t.Run("non empty", func(t *testing.T) {
 		cnrFrom.SetValue([]byte("Container ID"))
@@ -37,10 +36,9 @@ func TestContainerID_StableMarshal(t *testing.T) {
 		wire, err := cnrFrom.StableMarshal(nil)
 		require.NoError(t, err)
 
-		err = goproto.Unmarshal(wire, cnrTransport)
-		require.NoError(t, err)
+		cnrTo := new(refs.ContainerID)
+		require.NoError(t, cnrTo.Unmarshal(wire))
 
-		cnrTo := refs.ContainerIDFromGRPCMessage(cnrTransport)
 		require.Equal(t, cnrFrom, cnrTo)
 	})
 }

--- a/v2/refs/marshal_test.go
+++ b/v2/refs/marshal_test.go
@@ -47,7 +47,6 @@ func TestContainerID_StableMarshal(t *testing.T) {
 
 func TestObjectID_StableMarshal(t *testing.T) {
 	objectIDFrom := new(refs.ObjectID)
-	objectIDTransport := new(grpc.ObjectID)
 
 	t.Run("non empty", func(t *testing.T) {
 		objectIDFrom.SetValue([]byte("Object ID"))
@@ -55,10 +54,9 @@ func TestObjectID_StableMarshal(t *testing.T) {
 		wire, err := objectIDFrom.StableMarshal(nil)
 		require.NoError(t, err)
 
-		err = goproto.Unmarshal(wire, objectIDTransport)
-		require.NoError(t, err)
+		objectIDTo := new(refs.ObjectID)
+		require.NoError(t, objectIDTo.Unmarshal(wire))
 
-		objectIDTo := refs.ObjectIDFromGRPCMessage(objectIDTransport)
 		require.Equal(t, objectIDFrom, objectIDTo)
 	})
 }

--- a/v2/session/json.go
+++ b/v2/session/json.go
@@ -64,3 +64,23 @@ func (t *SessionTokenBody) UnmarshalJSON(data []byte) error {
 
 	return nil
 }
+
+func (t *SessionToken) MarshalJSON() ([]byte, error) {
+	return protojson.MarshalOptions{
+		EmitUnpopulated: true,
+	}.Marshal(
+		SessionTokenToGRPCMessage(t),
+	)
+}
+
+func (t *SessionToken) UnmarshalJSON(data []byte) error {
+	msg := new(session.SessionToken)
+
+	if err := protojson.Unmarshal(data, msg); err != nil {
+		return err
+	}
+
+	*t = *SessionTokenFromGRPCMessage(msg)
+
+	return nil
+}

--- a/v2/session/json.go
+++ b/v2/session/json.go
@@ -104,3 +104,23 @@ func (x *XHeader) UnmarshalJSON(data []byte) error {
 
 	return nil
 }
+
+func (r *RequestMetaHeader) MarshalJSON() ([]byte, error) {
+	return protojson.MarshalOptions{
+		EmitUnpopulated: true,
+	}.Marshal(
+		RequestMetaHeaderToGRPCMessage(r),
+	)
+}
+
+func (r *RequestMetaHeader) UnmarshalJSON(data []byte) error {
+	msg := new(session.RequestMetaHeader)
+
+	if err := protojson.Unmarshal(data, msg); err != nil {
+		return err
+	}
+
+	*r = *RequestMetaHeaderFromGRPCMessage(msg)
+
+	return nil
+}

--- a/v2/session/json.go
+++ b/v2/session/json.go
@@ -1,0 +1,26 @@
+package session
+
+import (
+	session "github.com/nspcc-dev/neofs-api-go/v2/session/grpc"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+func (c *ObjectSessionContext) MarshalJSON() ([]byte, error) {
+	return protojson.MarshalOptions{
+		EmitUnpopulated: true,
+	}.Marshal(
+		ObjectSessionContextToGRPCMessage(c),
+	)
+}
+
+func (c *ObjectSessionContext) UnmarshalJSON(data []byte) error {
+	msg := new(session.ObjectSessionContext)
+
+	if err := protojson.Unmarshal(data, msg); err != nil {
+		return err
+	}
+
+	*c = *ObjectSessionContextFromGRPCMessage(msg)
+
+	return nil
+}

--- a/v2/session/json.go
+++ b/v2/session/json.go
@@ -44,3 +44,23 @@ func (l *TokenLifetime) UnmarshalJSON(data []byte) error {
 
 	return nil
 }
+
+func (t *SessionTokenBody) MarshalJSON() ([]byte, error) {
+	return protojson.MarshalOptions{
+		EmitUnpopulated: true,
+	}.Marshal(
+		SessionTokenBodyToGRPCMessage(t),
+	)
+}
+
+func (t *SessionTokenBody) UnmarshalJSON(data []byte) error {
+	msg := new(session.SessionToken_Body)
+
+	if err := protojson.Unmarshal(data, msg); err != nil {
+		return err
+	}
+
+	*t = *SessionTokenBodyFromGRPCMessage(msg)
+
+	return nil
+}

--- a/v2/session/json.go
+++ b/v2/session/json.go
@@ -144,3 +144,23 @@ func (r *RequestVerificationHeader) UnmarshalJSON(data []byte) error {
 
 	return nil
 }
+
+func (r *ResponseMetaHeader) MarshalJSON() ([]byte, error) {
+	return protojson.MarshalOptions{
+		EmitUnpopulated: true,
+	}.Marshal(
+		ResponseMetaHeaderToGRPCMessage(r),
+	)
+}
+
+func (r *ResponseMetaHeader) UnmarshalJSON(data []byte) error {
+	msg := new(session.ResponseMetaHeader)
+
+	if err := protojson.Unmarshal(data, msg); err != nil {
+		return err
+	}
+
+	*r = *ResponseMetaHeaderFromGRPCMessage(msg)
+
+	return nil
+}

--- a/v2/session/json.go
+++ b/v2/session/json.go
@@ -164,3 +164,23 @@ func (r *ResponseMetaHeader) UnmarshalJSON(data []byte) error {
 
 	return nil
 }
+
+func (r *ResponseVerificationHeader) MarshalJSON() ([]byte, error) {
+	return protojson.MarshalOptions{
+		EmitUnpopulated: true,
+	}.Marshal(
+		ResponseVerificationHeaderToGRPCMessage(r),
+	)
+}
+
+func (r *ResponseVerificationHeader) UnmarshalJSON(data []byte) error {
+	msg := new(session.ResponseVerificationHeader)
+
+	if err := protojson.Unmarshal(data, msg); err != nil {
+		return err
+	}
+
+	*r = *ResponseVerificationHeaderFromGRPCMessage(msg)
+
+	return nil
+}

--- a/v2/session/json.go
+++ b/v2/session/json.go
@@ -84,3 +84,23 @@ func (t *SessionToken) UnmarshalJSON(data []byte) error {
 
 	return nil
 }
+
+func (x *XHeader) MarshalJSON() ([]byte, error) {
+	return protojson.MarshalOptions{
+		EmitUnpopulated: true,
+	}.Marshal(
+		XHeaderToGRPCMessage(x),
+	)
+}
+
+func (x *XHeader) UnmarshalJSON(data []byte) error {
+	msg := new(session.XHeader)
+
+	if err := protojson.Unmarshal(data, msg); err != nil {
+		return err
+	}
+
+	*x = *XHeaderFromGRPCMessage(msg)
+
+	return nil
+}

--- a/v2/session/json.go
+++ b/v2/session/json.go
@@ -124,3 +124,23 @@ func (r *RequestMetaHeader) UnmarshalJSON(data []byte) error {
 
 	return nil
 }
+
+func (r *RequestVerificationHeader) MarshalJSON() ([]byte, error) {
+	return protojson.MarshalOptions{
+		EmitUnpopulated: true,
+	}.Marshal(
+		RequestVerificationHeaderToGRPCMessage(r),
+	)
+}
+
+func (r *RequestVerificationHeader) UnmarshalJSON(data []byte) error {
+	msg := new(session.RequestVerificationHeader)
+
+	if err := protojson.Unmarshal(data, msg); err != nil {
+		return err
+	}
+
+	*r = *RequestVerificationHeaderFromGRPCMessage(msg)
+
+	return nil
+}

--- a/v2/session/json.go
+++ b/v2/session/json.go
@@ -24,3 +24,23 @@ func (c *ObjectSessionContext) UnmarshalJSON(data []byte) error {
 
 	return nil
 }
+
+func (l *TokenLifetime) MarshalJSON() ([]byte, error) {
+	return protojson.MarshalOptions{
+		EmitUnpopulated: true,
+	}.Marshal(
+		TokenLifetimeToGRPCMessage(l),
+	)
+}
+
+func (l *TokenLifetime) UnmarshalJSON(data []byte) error {
+	msg := new(session.SessionToken_Body_TokenLifetime)
+
+	if err := protojson.Unmarshal(data, msg); err != nil {
+		return err
+	}
+
+	*l = *TokenLifetimeFromGRPCMessage(msg)
+
+	return nil
+}

--- a/v2/session/json_test.go
+++ b/v2/session/json_test.go
@@ -42,3 +42,15 @@ func TestSessionTokenBodyJSON(t *testing.T) {
 
 	require.Equal(t, b, b2)
 }
+
+func TestSessionTokenJSON(t *testing.T) {
+	tok := generateSessionToken("id")
+
+	data, err := tok.MarshalJSON()
+	require.NoError(t, err)
+
+	tok2 := new(session.SessionToken)
+	require.NoError(t, tok2.UnmarshalJSON(data))
+
+	require.Equal(t, tok, tok2)
+}

--- a/v2/session/json_test.go
+++ b/v2/session/json_test.go
@@ -54,3 +54,15 @@ func TestSessionTokenJSON(t *testing.T) {
 
 	require.Equal(t, tok, tok2)
 }
+
+func TestXHeaderJSON(t *testing.T) {
+	x := generateXHeader("key", "value")
+
+	data, err := x.MarshalJSON()
+	require.NoError(t, err)
+
+	x2 := new(session.XHeader)
+	require.NoError(t, x2.UnmarshalJSON(data))
+
+	require.Equal(t, x, x2)
+}

--- a/v2/session/json_test.go
+++ b/v2/session/json_test.go
@@ -78,3 +78,15 @@ func TestRequestMetaHeaderJSON(t *testing.T) {
 
 	require.Equal(t, r, r2)
 }
+
+func TestRequestVerificationHeaderJSON(t *testing.T) {
+	r := generateRequestVerificationHeader("key", "value")
+
+	data, err := r.MarshalJSON()
+	require.NoError(t, err)
+
+	r2 := new(session.RequestVerificationHeader)
+	require.NoError(t, r2.UnmarshalJSON(data))
+
+	require.Equal(t, r, r2)
+}

--- a/v2/session/json_test.go
+++ b/v2/session/json_test.go
@@ -30,3 +30,15 @@ func TestTokenLifetimeJSON(t *testing.T) {
 
 	require.Equal(t, l, l2)
 }
+
+func TestSessionTokenBodyJSON(t *testing.T) {
+	b := generateSessionTokenBody("id")
+
+	data, err := b.MarshalJSON()
+	require.NoError(t, err)
+
+	b2 := new(session.SessionTokenBody)
+	require.NoError(t, b2.UnmarshalJSON(data))
+
+	require.Equal(t, b, b2)
+}

--- a/v2/session/json_test.go
+++ b/v2/session/json_test.go
@@ -90,3 +90,15 @@ func TestRequestVerificationHeaderJSON(t *testing.T) {
 
 	require.Equal(t, r, r2)
 }
+
+func TestResponseMetaHeaderJSON(t *testing.T) {
+	r := generateResponseMetaHeader(1)
+
+	data, err := r.MarshalJSON()
+	require.NoError(t, err)
+
+	r2 := new(session.ResponseMetaHeader)
+	require.NoError(t, r2.UnmarshalJSON(data))
+
+	require.Equal(t, r, r2)
+}

--- a/v2/session/json_test.go
+++ b/v2/session/json_test.go
@@ -102,3 +102,15 @@ func TestResponseMetaHeaderJSON(t *testing.T) {
 
 	require.Equal(t, r, r2)
 }
+
+func TestResponseVerificationHeaderJSON(t *testing.T) {
+	r := generateResponseVerificationHeader("key", "value")
+
+	data, err := r.MarshalJSON()
+	require.NoError(t, err)
+
+	r2 := new(session.ResponseVerificationHeader)
+	require.NoError(t, r2.UnmarshalJSON(data))
+
+	require.Equal(t, r, r2)
+}

--- a/v2/session/json_test.go
+++ b/v2/session/json_test.go
@@ -1,0 +1,20 @@
+package session_test
+
+import (
+	"testing"
+
+	"github.com/nspcc-dev/neofs-api-go/v2/session"
+	"github.com/stretchr/testify/require"
+)
+
+func TestChecksumJSON(t *testing.T) {
+	ctx := generateObjectCtx("id")
+
+	data, err := ctx.MarshalJSON()
+	require.NoError(t, err)
+
+	ctx2 := new(session.ObjectSessionContext)
+	require.NoError(t, ctx2.UnmarshalJSON(data))
+
+	require.Equal(t, ctx, ctx2)
+}

--- a/v2/session/json_test.go
+++ b/v2/session/json_test.go
@@ -18,3 +18,15 @@ func TestChecksumJSON(t *testing.T) {
 
 	require.Equal(t, ctx, ctx2)
 }
+
+func TestTokenLifetimeJSON(t *testing.T) {
+	l := generateLifetime(1, 2, 3)
+
+	data, err := l.MarshalJSON()
+	require.NoError(t, err)
+
+	l2 := new(session.TokenLifetime)
+	require.NoError(t, l2.UnmarshalJSON(data))
+
+	require.Equal(t, l, l2)
+}

--- a/v2/session/json_test.go
+++ b/v2/session/json_test.go
@@ -66,3 +66,15 @@ func TestXHeaderJSON(t *testing.T) {
 
 	require.Equal(t, x, x2)
 }
+
+func TestRequestMetaHeaderJSON(t *testing.T) {
+	r := generateRequestMetaHeader(1, "bearer", "session")
+
+	data, err := r.MarshalJSON()
+	require.NoError(t, err)
+
+	r2 := new(session.RequestMetaHeader)
+	require.NoError(t, r2.UnmarshalJSON(data))
+
+	require.Equal(t, r, r2)
+}

--- a/v2/session/marshal.go
+++ b/v2/session/marshal.go
@@ -595,6 +595,17 @@ func (r *RequestVerificationHeader) StableSize() (size int) {
 	return size
 }
 
+func (r *RequestVerificationHeader) Unmarshal(data []byte) error {
+	m := new(session.RequestVerificationHeader)
+	if err := goproto.Unmarshal(data, m); err != nil {
+		return err
+	}
+
+	*r = *RequestVerificationHeaderFromGRPCMessage(m)
+
+	return nil
+}
+
 func (r *ResponseMetaHeader) StableMarshal(buf []byte) ([]byte, error) {
 	if r == nil {
 		return []byte{}, nil

--- a/v2/session/marshal.go
+++ b/v2/session/marshal.go
@@ -745,3 +745,14 @@ func (r *ResponseVerificationHeader) StableSize() (size int) {
 
 	return size
 }
+
+func (r *ResponseVerificationHeader) Unmarshal(data []byte) error {
+	m := new(session.ResponseVerificationHeader)
+	if err := goproto.Unmarshal(data, m); err != nil {
+		return err
+	}
+
+	*r = *ResponseVerificationHeaderFromGRPCMessage(m)
+
+	return nil
+}

--- a/v2/session/marshal.go
+++ b/v2/session/marshal.go
@@ -417,6 +417,17 @@ func (t *SessionToken) StableSize() (size int) {
 	return size
 }
 
+func (t *SessionToken) Unmarshal(data []byte) error {
+	m := new(session.SessionToken)
+	if err := goproto.Unmarshal(data, m); err != nil {
+		return err
+	}
+
+	*t = *SessionTokenFromGRPCMessage(m)
+
+	return nil
+}
+
 func (r *RequestMetaHeader) StableMarshal(buf []byte) ([]byte, error) {
 	if r == nil {
 		return []byte{}, nil

--- a/v2/session/marshal.go
+++ b/v2/session/marshal.go
@@ -366,6 +366,17 @@ func (t *SessionTokenBody) StableSize() (size int) {
 	return size
 }
 
+func (t *SessionTokenBody) Unmarshal(data []byte) error {
+	m := new(session.SessionToken_Body)
+	if err := goproto.Unmarshal(data, m); err != nil {
+		return err
+	}
+
+	*t = *SessionTokenBodyFromGRPCMessage(m)
+
+	return nil
+}
+
 func (t *SessionToken) StableMarshal(buf []byte) ([]byte, error) {
 	if t == nil {
 		return []byte{}, nil

--- a/v2/session/marshal.go
+++ b/v2/session/marshal.go
@@ -2,6 +2,8 @@ package session
 
 import (
 	"github.com/nspcc-dev/neofs-api-go/util/proto"
+	session "github.com/nspcc-dev/neofs-api-go/v2/session/grpc"
+	goproto "google.golang.org/protobuf/proto"
 )
 
 const (
@@ -261,6 +263,17 @@ func (c *ObjectSessionContext) StableSize() (size int) {
 	size += proto.NestedStructureSize(objectCtxAddressField, c.addr)
 
 	return size
+}
+
+func (c *ObjectSessionContext) Unmarshal(data []byte) error {
+	m := new(session.ObjectSessionContext)
+	if err := goproto.Unmarshal(data, m); err != nil {
+		return err
+	}
+
+	*c = *ObjectSessionContextFromGRPCMessage(m)
+
+	return nil
 }
 
 func (t *SessionTokenBody) StableMarshal(buf []byte) ([]byte, error) {

--- a/v2/session/marshal.go
+++ b/v2/session/marshal.go
@@ -225,6 +225,17 @@ func (l *TokenLifetime) StableSize() (size int) {
 	return size
 }
 
+func (l *TokenLifetime) Unmarshal(data []byte) error {
+	m := new(session.SessionToken_Body_TokenLifetime)
+	if err := goproto.Unmarshal(data, m); err != nil {
+		return err
+	}
+
+	*l = *TokenLifetimeFromGRPCMessage(m)
+
+	return nil
+}
+
 func (c *ObjectSessionContext) StableMarshal(buf []byte) ([]byte, error) {
 	if c == nil {
 		return []byte{}, nil

--- a/v2/session/marshal.go
+++ b/v2/session/marshal.go
@@ -528,6 +528,17 @@ func (r *RequestMetaHeader) StableSize() (size int) {
 	return size
 }
 
+func (r *RequestMetaHeader) Unmarshal(data []byte) error {
+	m := new(session.RequestMetaHeader)
+	if err := goproto.Unmarshal(data, m); err != nil {
+		return err
+	}
+
+	*r = *RequestMetaHeaderFromGRPCMessage(m)
+
+	return nil
+}
+
 func (r *RequestVerificationHeader) StableMarshal(buf []byte) ([]byte, error) {
 	if r == nil {
 		return []byte{}, nil

--- a/v2/session/marshal.go
+++ b/v2/session/marshal.go
@@ -679,6 +679,17 @@ func (r *ResponseMetaHeader) StableSize() (size int) {
 	return size
 }
 
+func (r *ResponseMetaHeader) Unmarshal(data []byte) error {
+	m := new(session.ResponseMetaHeader)
+	if err := goproto.Unmarshal(data, m); err != nil {
+		return err
+	}
+
+	*r = *ResponseMetaHeaderFromGRPCMessage(m)
+
+	return nil
+}
+
 func (r *ResponseVerificationHeader) StableMarshal(buf []byte) ([]byte, error) {
 	if r == nil {
 		return []byte{}, nil

--- a/v2/session/marshal.go
+++ b/v2/session/marshal.go
@@ -177,6 +177,17 @@ func (x *XHeader) StableSize() (size int) {
 	return size
 }
 
+func (x *XHeader) Unmarshal(data []byte) error {
+	m := new(session.XHeader)
+	if err := goproto.Unmarshal(data, m); err != nil {
+		return err
+	}
+
+	*x = *XHeaderFromGRPCMessage(m)
+
+	return nil
+}
+
 func (l *TokenLifetime) StableMarshal(buf []byte) ([]byte, error) {
 	if l == nil {
 		return []byte{}, nil

--- a/v2/session/marshal_test.go
+++ b/v2/session/marshal_test.go
@@ -62,16 +62,14 @@ func TestXHeader_StableMarshal(t *testing.T) {
 
 func TestTokenLifetime_StableMarshal(t *testing.T) {
 	lifetimeFrom := generateLifetime(10, 20, 30)
-	transport := new(grpc.SessionToken_Body_TokenLifetime)
 
 	t.Run("non empty", func(t *testing.T) {
 		wire, err := lifetimeFrom.StableMarshal(nil)
 		require.NoError(t, err)
 
-		err = goproto.Unmarshal(wire, transport)
-		require.NoError(t, err)
+		lifetimeTo := new(session.TokenLifetime)
+		require.NoError(t, lifetimeTo.Unmarshal(wire))
 
-		lifetimeTo := session.TokenLifetimeFromGRPCMessage(transport)
 		require.Equal(t, lifetimeFrom, lifetimeTo)
 	})
 }

--- a/v2/session/marshal_test.go
+++ b/v2/session/marshal_test.go
@@ -166,16 +166,14 @@ func TestResponseVerificationHeader_StableMarshal(t *testing.T) {
 	verifHeaderOrigin := generateResponseVerificationHeader("Key", "Inside")
 	verifHeaderFrom := generateResponseVerificationHeader("Value", "Outside")
 	verifHeaderFrom.SetOrigin(verifHeaderOrigin)
-	transport := new(grpc.ResponseVerificationHeader)
 
 	t.Run("non empty", func(t *testing.T) {
 		wire, err := verifHeaderFrom.StableMarshal(nil)
 		require.NoError(t, err)
 
-		err = goproto.Unmarshal(wire, transport)
-		require.NoError(t, err)
+		verifHeaderTo := new(session.ResponseVerificationHeader)
+		require.NoError(t, verifHeaderTo.Unmarshal(wire))
 
-		verifHeaderTo := session.ResponseVerificationHeaderFromGRPCMessage(transport)
 		require.Equal(t, verifHeaderFrom, verifHeaderTo)
 	})
 }

--- a/v2/session/marshal_test.go
+++ b/v2/session/marshal_test.go
@@ -150,16 +150,14 @@ func TestResponseMetaHeader_StableMarshal(t *testing.T) {
 	metaHeaderOrigin := generateResponseMetaHeader(10)
 	metaHeaderFrom := generateResponseMetaHeader(20)
 	metaHeaderFrom.SetOrigin(metaHeaderOrigin)
-	transport := new(grpc.ResponseMetaHeader)
 
 	t.Run("non empty", func(t *testing.T) {
 		wire, err := metaHeaderFrom.StableMarshal(nil)
 		require.NoError(t, err)
 
-		err = goproto.Unmarshal(wire, transport)
-		require.NoError(t, err)
+		metaHeaderTo := new(session.ResponseMetaHeader)
+		require.NoError(t, metaHeaderTo.Unmarshal(wire))
 
-		metaHeaderTo := session.ResponseMetaHeaderFromGRPCMessage(transport)
 		require.Equal(t, metaHeaderFrom, metaHeaderTo)
 	})
 }

--- a/v2/session/marshal_test.go
+++ b/v2/session/marshal_test.go
@@ -90,16 +90,14 @@ func TestObjectSessionContext_StableMarshal(t *testing.T) {
 
 func TestSessionTokenBody_StableMarshal(t *testing.T) {
 	sessionTokenBodyFrom := generateSessionTokenBody("Session Token Body")
-	transport := new(grpc.SessionToken_Body)
 
 	t.Run("non empty", func(t *testing.T) {
 		wire, err := sessionTokenBodyFrom.StableMarshal(nil)
 		require.NoError(t, err)
 
-		err = goproto.Unmarshal(wire, transport)
-		require.NoError(t, err)
+		sessionTokenBodyTo := new(session.SessionTokenBody)
+		require.NoError(t, sessionTokenBodyTo.Unmarshal(wire))
 
-		sessionTokenBodyTo := session.SessionTokenBodyFromGRPCMessage(transport)
 		require.Equal(t, sessionTokenBodyFrom, sessionTokenBodyTo)
 	})
 }

--- a/v2/session/marshal_test.go
+++ b/v2/session/marshal_test.go
@@ -78,16 +78,14 @@ func TestTokenLifetime_StableMarshal(t *testing.T) {
 
 func TestObjectSessionContext_StableMarshal(t *testing.T) {
 	objectCtxFrom := generateObjectCtx("Object ID")
-	transport := new(grpc.ObjectSessionContext)
 
 	t.Run("non empty", func(t *testing.T) {
 		wire, err := objectCtxFrom.StableMarshal(nil)
 		require.NoError(t, err)
 
-		err = goproto.Unmarshal(wire, transport)
-		require.NoError(t, err)
+		objectCtxTo := new(session.ObjectSessionContext)
+		require.NoError(t, objectCtxTo.Unmarshal(wire))
 
-		objectCtxTo := session.ObjectSessionContextFromGRPCMessage(transport)
 		require.Equal(t, objectCtxFrom, objectCtxTo)
 	})
 }

--- a/v2/session/marshal_test.go
+++ b/v2/session/marshal_test.go
@@ -134,16 +134,14 @@ func TestRequestVerificationHeader_StableMarshal(t *testing.T) {
 	verifHeaderOrigin := generateRequestVerificationHeader("Key", "Inside")
 	verifHeaderFrom := generateRequestVerificationHeader("Value", "Outside")
 	verifHeaderFrom.SetOrigin(verifHeaderOrigin)
-	transport := new(grpc.RequestVerificationHeader)
 
 	t.Run("non empty", func(t *testing.T) {
 		wire, err := verifHeaderFrom.StableMarshal(nil)
 		require.NoError(t, err)
 
-		err = goproto.Unmarshal(wire, transport)
-		require.NoError(t, err)
+		verifHeaderTo := new(session.RequestVerificationHeader)
+		require.NoError(t, verifHeaderTo.Unmarshal(wire))
 
-		verifHeaderTo := session.RequestVerificationHeaderFromGRPCMessage(transport)
 		require.Equal(t, verifHeaderFrom, verifHeaderTo)
 	})
 }

--- a/v2/session/marshal_test.go
+++ b/v2/session/marshal_test.go
@@ -46,16 +46,14 @@ func TestCreateResponseBody_StableMarshal(t *testing.T) {
 
 func TestXHeader_StableMarshal(t *testing.T) {
 	xheaderFrom := generateXHeader("X-Header-Key", "X-Header-Value")
-	transport := new(grpc.XHeader)
 
 	t.Run("non empty", func(t *testing.T) {
 		wire, err := xheaderFrom.StableMarshal(nil)
 		require.NoError(t, err)
 
-		err = goproto.Unmarshal(wire, transport)
-		require.NoError(t, err)
+		xheaderTo := new(session.XHeader)
+		require.NoError(t, xheaderTo.Unmarshal(wire))
 
-		xheaderTo := session.XHeaderFromGRPCMessage(transport)
 		require.Equal(t, xheaderFrom, xheaderTo)
 	})
 }

--- a/v2/session/marshal_test.go
+++ b/v2/session/marshal_test.go
@@ -104,16 +104,14 @@ func TestSessionTokenBody_StableMarshal(t *testing.T) {
 
 func TestSessionToken_StableMarshal(t *testing.T) {
 	sessionTokenFrom := generateSessionToken("Session Token")
-	transport := new(grpc.SessionToken)
 
 	t.Run("non empty", func(t *testing.T) {
 		wire, err := sessionTokenFrom.StableMarshal(nil)
 		require.NoError(t, err)
 
-		err = goproto.Unmarshal(wire, transport)
-		require.NoError(t, err)
+		sessionTokenTo := new(session.SessionToken)
+		require.NoError(t, sessionTokenTo.Unmarshal(wire))
 
-		sessionTokenTo := session.SessionTokenFromGRPCMessage(transport)
 		require.Equal(t, sessionTokenFrom, sessionTokenTo)
 	})
 }

--- a/v2/session/marshal_test.go
+++ b/v2/session/marshal_test.go
@@ -118,16 +118,14 @@ func TestRequestMetaHeader_StableMarshal(t *testing.T) {
 	metaHeaderOrigin := generateRequestMetaHeader(10, "Bearer One", "Session One")
 	metaHeaderFrom := generateRequestMetaHeader(20, "Bearer Two", "Session Two")
 	metaHeaderFrom.SetOrigin(metaHeaderOrigin)
-	transport := new(grpc.RequestMetaHeader)
 
 	t.Run("non empty", func(t *testing.T) {
 		wire, err := metaHeaderFrom.StableMarshal(nil)
 		require.NoError(t, err)
 
-		err = goproto.Unmarshal(wire, transport)
-		require.NoError(t, err)
+		metaHeaderTo := new(session.RequestMetaHeader)
+		require.NoError(t, metaHeaderTo.Unmarshal(wire))
 
-		metaHeaderTo := session.RequestMetaHeaderFromGRPCMessage(transport)
 		require.Equal(t, metaHeaderFrom, metaHeaderTo)
 	})
 }

--- a/v2/storagegroup/json.go
+++ b/v2/storagegroup/json.go
@@ -1,0 +1,26 @@
+package storagegroup
+
+import (
+	storagegroup "github.com/nspcc-dev/neofs-api-go/v2/storagegroup/grpc"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+func (s *StorageGroup) MarshalJSON() ([]byte, error) {
+	return protojson.MarshalOptions{
+		EmitUnpopulated: true,
+	}.Marshal(
+		StorageGroupToGRPCMessage(s),
+	)
+}
+
+func (s *StorageGroup) UnmarshalJSON(data []byte) error {
+	msg := new(storagegroup.StorageGroup)
+
+	if err := protojson.Unmarshal(data, msg); err != nil {
+		return err
+	}
+
+	*s = *StorageGroupFromGRPCMessage(msg)
+
+	return nil
+}

--- a/v2/storagegroup/json_test.go
+++ b/v2/storagegroup/json_test.go
@@ -1,0 +1,20 @@
+package storagegroup_test
+
+import (
+	"testing"
+
+	"github.com/nspcc-dev/neofs-api-go/v2/storagegroup"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStorageGroupJSON(t *testing.T) {
+	sg := generateSG()
+
+	data, err := sg.MarshalJSON()
+	require.NoError(t, err)
+
+	sg2 := new(storagegroup.StorageGroup)
+	require.NoError(t, sg2.UnmarshalJSON(data))
+
+	require.Equal(t, sg, sg2)
+}

--- a/v2/storagegroup/marshal.go
+++ b/v2/storagegroup/marshal.go
@@ -2,6 +2,8 @@ package storagegroup
 
 import (
 	"github.com/nspcc-dev/neofs-api-go/util/proto"
+	storagegroup "github.com/nspcc-dev/neofs-api-go/v2/storagegroup/grpc"
+	goproto "google.golang.org/protobuf/proto"
 )
 
 const (
@@ -75,4 +77,15 @@ func (s *StorageGroup) StableSize() (size int) {
 	}
 
 	return size
+}
+
+func (s *StorageGroup) Unmarshal(data []byte) error {
+	m := new(storagegroup.StorageGroup)
+	if err := goproto.Unmarshal(data, m); err != nil {
+		return err
+	}
+
+	*s = *StorageGroupFromGRPCMessage(m)
+
+	return nil
 }

--- a/v2/storagegroup/marshal_test.go
+++ b/v2/storagegroup/marshal_test.go
@@ -5,34 +5,19 @@ import (
 
 	"github.com/nspcc-dev/neofs-api-go/v2/refs"
 	"github.com/nspcc-dev/neofs-api-go/v2/storagegroup"
-	grpc "github.com/nspcc-dev/neofs-api-go/v2/storagegroup/grpc"
 	"github.com/stretchr/testify/require"
-	goproto "google.golang.org/protobuf/proto"
 )
 
 func TestStorageGroup_StableMarshal(t *testing.T) {
-	ownerID1 := new(refs.ObjectID)
-	ownerID1.SetValue([]byte("Object ID 1"))
-
-	ownerID2 := new(refs.ObjectID)
-	ownerID2.SetValue([]byte("Object ID 2"))
-
-	storageGroupFrom := new(storagegroup.StorageGroup)
-	transport := new(grpc.StorageGroup)
+	storageGroupFrom := generateSG()
 
 	t.Run("non empty", func(t *testing.T) {
-		storageGroupFrom.SetValidationDataSize(300)
-		storageGroupFrom.SetValidationHash(generateChecksum("Homomorphic hash"))
-		storageGroupFrom.SetExpirationEpoch(100)
-		storageGroupFrom.SetMembers([]*refs.ObjectID{ownerID1, ownerID2})
-
 		wire, err := storageGroupFrom.StableMarshal(nil)
 		require.NoError(t, err)
 
-		err = goproto.Unmarshal(wire, transport)
-		require.NoError(t, err)
+		storageGroupTo := new(storagegroup.StorageGroup)
+		require.NoError(t, storageGroupTo.Unmarshal(wire))
 
-		storageGroupTo := storagegroup.StorageGroupFromGRPCMessage(transport)
 		require.Equal(t, storageGroupFrom, storageGroupTo)
 	})
 }
@@ -43,4 +28,21 @@ func generateChecksum(data string) *refs.Checksum {
 	checksum.SetSum([]byte(data))
 
 	return checksum
+}
+
+func generateSG() *storagegroup.StorageGroup {
+	sg := new(storagegroup.StorageGroup)
+
+	oid1 := new(refs.ObjectID)
+	oid1.SetValue([]byte("Object ID 1"))
+
+	oid2 := new(refs.ObjectID)
+	oid2.SetValue([]byte("Object ID 2"))
+
+	sg.SetValidationDataSize(300)
+	sg.SetValidationHash(generateChecksum("Homomorphic hash"))
+	sg.SetExpirationEpoch(100)
+	sg.SetMembers([]*refs.ObjectID{oid1, oid2})
+
+	return sg
 }


### PR DESCRIPTION
Closes #168.
### Netmap
- [x] Filter

- [x] Selector

- [x] Replica

- [x] PlacementPolicy

- [x] NodeInfo.Attribute

- [x] NodeInfo
### Accounting

- [x] Decimal
### ACL

- [x] EACLRecord.Filter

- [x] EACLRecord.Target

- [x] EACLRecord

- [x] EACLTable

- [x] BearerToken.Body.TokenLifetime

- [x] BearerToken.Body

- [x] BearerToken
### Container

- [x] Container.Attribute

- [x] Container
### Object

- [x] ShortHeader

- [x] Header.Attribute

- [x] Header.Split

- [x] Header

- [x] HeaderWithSignature

- [x] Object
### Refs

- [x] Address

- [x] ObjectID

- [x] ContainerID

- [x] OwnerID

- [x] Version

- [x] Signature

- [x] Checksum
### Session

- [x] ObjectSessionContext

- [x] SessionToken.Body.TokenLifetime

- [x] SessionToken.Body

- [x] SessionToken

- [x] XHeader

- [x] RequestMetaHeader

- [x] ResponseMetaHeader

- [x] RequestVerificationHeader

- [x] ResponseVerificationHeader
### Storagegroup

- [x] StorageGroup