### PR TITLE
Fix signature check in object header getter

### DIFF
--- a/pkg/client/object.go
+++ b/pkg/client/object.go
@@ -579,7 +579,7 @@ func (c *Client) getObjectHeaderV2(ctx context.Context, p *ObjectHeaderParams, o
 
 		if err := signer.VerifyDataWithSource(
 			signature.StableMarshalerWrapper{
-				SM: hdrWithSig.GetHeader(),
+				SM: p.addr.ObjectID().ToV2(),
 			},
 			func() (key, sig []byte) {
 				s := hdrWithSig.GetSignature()


### PR DESCRIPTION
According to API object.Head response contains signature of object ID rather than signature of object header itself.