### PR TITLE
sdk/client: Fix signature verification in GetEACL method

### DIFF
--- a/pkg/client/container.go
+++ b/pkg/client/container.go
@@ -367,6 +367,7 @@ func (c Client) getEACLV2(ctx context.Context, id *container.ID, opts ...CallOpt
 
 				return s.GetKey(), s.GetSign()
 			},
+			signature.SignWithRFC6979(),
 		); err != nil {
 			return nil, errors.Wrap(err, "incorrect signature")
 		}


### PR DESCRIPTION
Extended ACL tables should be signed with RFC-6979 standard. Fix `Client.GetEACL` implementation to verify eACL signature with `SignRFC6979` option.

Additionally implemented `Client.GetEACLWithSignatureMethod` that returns eACL with signature w/o the verification.