### PR TITLE
Verify container nonce format (UUID)

### DIFF
--- a/pkg/client/container.go
+++ b/pkg/client/container.go
@@ -55,6 +55,9 @@ func (c Client) PutContainer(ctx context.Context, cnr *container.Container, opts
 	}
 }
 
+// GetContainer receives container structure through NeoFS API call.
+//
+// Returns error if container structure is received but does not meet NeoFS API specification.
 func (c Client) GetContainer(ctx context.Context, id *container.ID, opts ...CallOption) (*container.Container, error) {
 	switch c.remoteNode.Version.Major() {
 	case 2:
@@ -259,7 +262,7 @@ func (c Client) getContainerV2(ctx context.Context, id *container.ID, opts ...Ca
 			return nil, errors.Wrap(err, "can't verify response message")
 		}
 
-		return container.NewContainerFromV2(resp.GetBody().GetContainer()), nil
+		return container.NewVerifiedFromV2(resp.GetBody().GetContainer())
 	default:
 		return nil, errUnsupportedProtocol
 	}

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -42,6 +42,10 @@ func (c *Container) ToV2() *container.Container {
 	return &c.v2
 }
 
+// NewVerifiedFromV2 constructs Container from NeoFS API V2 Container message.
+//
+// Does not perform if message meets NeoFS API V2 specification. To do this
+// use NewVerifiedFromV2 constructor.
 func NewContainerFromV2(c *container.Container) *Container {
 	cnr := new(Container)
 

--- a/pkg/container/container_test.go
+++ b/pkg/container/container_test.go
@@ -17,8 +17,7 @@ import (
 func TestNewContainer(t *testing.T) {
 	c := container.New()
 
-	nonce, err := uuid.New().MarshalBinary()
-	require.NoError(t, err)
+	nonce := uuid.New()
 
 	wallet, err := owner.NEO3WalletFromPublicKey(&test.DecodeKey(1).PublicKey)
 	require.NoError(t, err)
@@ -29,7 +28,7 @@ func TestNewContainer(t *testing.T) {
 	c.SetBasicACL(acl.PublicBasicRule)
 	c.SetAttributes(generateAttributes(5))
 	c.SetPlacementPolicy(policy)
-	c.SetNonce(nonce)
+	c.SetNonceUUID(nonce)
 	c.SetOwnerID(ownerID)
 	c.SetVersion(pkg.SDKVersion())
 
@@ -39,7 +38,11 @@ func TestNewContainer(t *testing.T) {
 	require.EqualValues(t, newContainer.PlacementPolicy(), policy)
 	require.EqualValues(t, newContainer.Attributes(), generateAttributes(5))
 	require.EqualValues(t, newContainer.BasicACL(), acl.PublicBasicRule)
-	require.EqualValues(t, newContainer.Nonce(), nonce)
+
+	newNonce, err := newContainer.NonceUUID()
+	require.NoError(t, err)
+
+	require.EqualValues(t, newNonce, nonce)
 	require.EqualValues(t, newContainer.OwnerID(), ownerID)
 	require.EqualValues(t, newContainer.Version(), pkg.SDKVersion())
 }

--- a/pkg/container/fmt.go
+++ b/pkg/container/fmt.go
@@ -1,0 +1,27 @@
+package container
+
+import (
+	"github.com/nspcc-dev/neofs-api-go/pkg"
+	"github.com/nspcc-dev/neofs-api-go/v2/container"
+	"github.com/pkg/errors"
+)
+
+// NewVerifiedFromV2 constructs Container from NeoFS API V2 Container message.
+// Returns error if message does not meet NeoFS API V2 specification.
+//
+// Additionally checks if message carries supported version.
+func NewVerifiedFromV2(cnrV2 *container.Container) (*Container, error) {
+	cnr := NewContainerFromV2(cnrV2)
+
+	// check version support
+	if err := pkg.IsSupportedVersion(cnr.Version()); err != nil {
+		return nil, err
+	}
+
+	// check nonce format
+	if _, err := cnr.NonceUUID(); err != nil {
+		return nil, errors.Wrap(err, "invalid nonce")
+	}
+
+	return cnr, nil
+}

--- a/pkg/container/fmt_test.go
+++ b/pkg/container/fmt_test.go
@@ -1,0 +1,49 @@
+package container_test
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/nspcc-dev/neofs-api-go/pkg"
+	"github.com/nspcc-dev/neofs-api-go/pkg/container"
+	containerV2 "github.com/nspcc-dev/neofs-api-go/v2/container"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewVerifiedFromV2(t *testing.T) {
+	cnrV2 := new(containerV2.Container)
+
+	errAssert := func() {
+		_, err := container.NewVerifiedFromV2(cnrV2)
+		require.Error(t, err)
+	}
+
+	// set unsupported version
+	v := pkg.SDKVersion()
+	v.SetMajor(0)
+	require.Error(t, pkg.IsSupportedVersion(v))
+	cnrV2.SetVersion(v.ToV2())
+
+	errAssert()
+
+	// set supported version
+	v.SetMajor(2)
+	require.NoError(t, pkg.IsSupportedVersion(v))
+	cnrV2.SetVersion(v.ToV2())
+
+	errAssert()
+
+	// set invalid nonce
+	nonce := []byte{1, 2, 3}
+	cnrV2.SetNonce(nonce)
+
+	errAssert()
+
+	// set valid nonce
+	uid := uuid.New()
+	data, _ := uid.MarshalBinary()
+	cnrV2.SetNonce(data)
+
+	_, err := container.NewVerifiedFromV2(cnrV2)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
- implement getter and setter of container nonce which works with UUID type;
- implement constructor of pkg/container.Container which preliminary verifies message format.

Closes #194.