### PR TITLE
container: Implement marshalers on UsedSpaceAnnouncement

### DIFF
--- a/pkg/container/announcement.go
+++ b/pkg/container/announcement.go
@@ -55,3 +55,23 @@ func (a *UsedSpaceAnnouncement) SetUsedSpace(value uint64) {
 func (a *UsedSpaceAnnouncement) ToV2() *container.UsedSpaceAnnouncement {
 	return (*container.UsedSpaceAnnouncement)(a)
 }
+
+// Marshal marshals UsedSpaceAnnouncement into a protobuf binary form.
+//
+// Buffer is allocated when the argument is empty.
+// Otherwise, the first buffer is used.
+func (a *UsedSpaceAnnouncement) Marshal(b ...[]byte) ([]byte, error) {
+	var buf []byte
+	if len(b) > 0 {
+		buf = b[0]
+	}
+
+	return a.ToV2().
+		StableMarshal(buf)
+}
+
+// Unmarshal unmarshals protobuf binary representation of UsedSpaceAnnouncement.
+func (a *UsedSpaceAnnouncement) Unmarshal(data []byte) error {
+	return a.ToV2().
+		Unmarshal(data)
+}

--- a/pkg/container/announcement_test.go
+++ b/pkg/container/announcement_test.go
@@ -1,6 +1,7 @@
 package container_test
 
 import (
+	"crypto/sha256"
 	"testing"
 
 	"github.com/nspcc-dev/neofs-api-go/pkg/container"
@@ -45,5 +46,26 @@ func TestAnnouncement(t *testing.T) {
 		require.Equal(t, newEpoch, newA.Epoch())
 		require.Equal(t, newUsedSpace, newA.UsedSpace())
 		require.Equal(t, container.NewIDFromV2(newCID), newA.ContainerID())
+	})
+}
+
+func TestUsedSpaceEncoding(t *testing.T) {
+	a := container.NewAnnouncement()
+	a.SetUsedSpace(13)
+	a.SetEpoch(666)
+
+	id := container.NewID()
+	id.SetSHA256([sha256.Size]byte{1, 2, 3})
+
+	a.SetContainerID(id)
+
+	t.Run("binary", func(t *testing.T) {
+		data, err := a.Marshal()
+		require.NoError(t, err)
+
+		a2 := container.NewAnnouncement()
+		require.NoError(t, a2.Unmarshal(data))
+
+		require.Equal(t, a, a2)
 	})
 }

--- a/v2/container/marshal.go
+++ b/v2/container/marshal.go
@@ -589,6 +589,17 @@ func (a *UsedSpaceAnnouncement) StableSize() (size int) {
 	return size
 }
 
+func (a *UsedSpaceAnnouncement) Unmarshal(data []byte) error {
+	m := new(container.AnnounceUsedSpaceRequest_Body_Announcement)
+	if err := proto.Unmarshal(data, m); err != nil {
+		return err
+	}
+
+	*a = *UsedSpaceAnnouncementFromGRPCMessage(m)
+
+	return nil
+}
+
 func (r *AnnounceUsedSpaceRequestBody) StableMarshal(buf []byte) ([]byte, error) {
 	if r == nil {
 		return []byte{}, nil


### PR DESCRIPTION
Implement Unmarshal method on UsedSpaceAnnouncement v2 message. Implement
Marshal/Unmarshal methods on cross-version UsedSpaceAnnouncement type.

Signed-off-by: Leonard Lyubich <leonard@nspcc.ru>