### PR TITLE
Provide client key in call options

### DIFF
--- a/pkg/client/accounting.go
+++ b/pkg/client/accounting.go
@@ -34,7 +34,7 @@ func (c Client) getBalanceV2(ctx context.Context, ownerID *owner.ID, opts ...Cal
 	}
 
 	if ownerID == nil {
-		w, err := owner.NEO3WalletFromPublicKey(&c.key.PublicKey)
+		w, err := owner.NEO3WalletFromPublicKey(&callOptions.key.PublicKey)
 		if err != nil {
 			return nil, err
 		}
@@ -50,7 +50,7 @@ func (c Client) getBalanceV2(ctx context.Context, ownerID *owner.ID, opts ...Cal
 	req.SetBody(reqBody)
 	req.SetMetaHeader(v2MetaHeaderFromOpts(callOptions))
 
-	err := v2signature.SignServiceMessage(c.key, req)
+	err := v2signature.SignServiceMessage(callOptions.key, req)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/accounting.go
+++ b/pkg/client/accounting.go
@@ -12,15 +12,7 @@ import (
 )
 
 func (c Client) GetSelfBalance(ctx context.Context, opts ...CallOption) (*accounting.Decimal, error) {
-	w, err := owner.NEO3WalletFromPublicKey(&c.key.PublicKey)
-	if err != nil {
-		return nil, err
-	}
-
-	ownerID := new(owner.ID)
-	ownerID.SetNeo3Wallet(w)
-
-	return c.GetBalance(ctx, ownerID, opts...)
+	return c.GetBalance(ctx, nil, opts...)
 }
 
 func (c Client) GetBalance(ctx context.Context, owner *owner.ID, opts ...CallOption) (*accounting.Decimal, error) {
@@ -33,7 +25,7 @@ func (c Client) GetBalance(ctx context.Context, owner *owner.ID, opts ...CallOpt
 	}
 }
 
-func (c Client) getBalanceV2(ctx context.Context, owner *owner.ID, opts ...CallOption) (*accounting.Decimal, error) {
+func (c Client) getBalanceV2(ctx context.Context, ownerID *owner.ID, opts ...CallOption) (*accounting.Decimal, error) {
 	// apply all available options
 	callOptions := c.defaultCallOptions()
 
@@ -41,8 +33,18 @@ func (c Client) getBalanceV2(ctx context.Context, owner *owner.ID, opts ...CallO
 		opts[i].apply(&callOptions)
 	}
 
+	if ownerID == nil {
+		w, err := owner.NEO3WalletFromPublicKey(&c.key.PublicKey)
+		if err != nil {
+			return nil, err
+		}
+
+		ownerID = new(owner.ID)
+		ownerID.SetNeo3Wallet(w)
+	}
+
 	reqBody := new(v2accounting.BalanceRequestBody)
-	reqBody.SetOwnerID(owner.ToV2())
+	reqBody.SetOwnerID(ownerID.ToV2())
 
 	req := new(v2accounting.BalanceRequest)
 	req.SetBody(reqBody)

--- a/pkg/client/container.go
+++ b/pkg/client/container.go
@@ -94,15 +94,7 @@ func (c Client) ListContainers(ctx context.Context, owner *owner.ID, opts ...Cal
 }
 
 func (c Client) ListSelfContainers(ctx context.Context, opts ...CallOption) ([]*container.ID, error) {
-	w, err := owner.NEO3WalletFromPublicKey(&c.key.PublicKey)
-	if err != nil {
-		return nil, err
-	}
-
-	ownerID := new(owner.ID)
-	ownerID.SetNeo3Wallet(w)
-
-	return c.ListContainers(ctx, ownerID, opts...)
+	return c.ListContainers(ctx, nil, opts...)
 }
 
 func (c Client) DeleteContainer(ctx context.Context, id *container.ID, opts ...CallOption) error {
@@ -282,7 +274,7 @@ func (c Client) getContainerV2(ctx context.Context, id *container.ID, opts ...Ca
 	}
 }
 
-func (c Client) listContainerV2(ctx context.Context, owner *owner.ID, opts ...CallOption) ([]*container.ID, error) {
+func (c Client) listContainerV2(ctx context.Context, ownerID *owner.ID, opts ...CallOption) ([]*container.ID, error) {
 	// apply all available options
 	callOptions := c.defaultCallOptions()
 
@@ -290,8 +282,18 @@ func (c Client) listContainerV2(ctx context.Context, owner *owner.ID, opts ...Ca
 		opts[i].apply(&callOptions)
 	}
 
+	if ownerID == nil {
+		w, err := owner.NEO3WalletFromPublicKey(&c.key.PublicKey)
+		if err != nil {
+			return nil, err
+		}
+
+		ownerID = new(owner.ID)
+		ownerID.SetNeo3Wallet(w)
+	}
+
 	reqBody := new(v2container.ListRequestBody)
-	reqBody.SetOwnerID(owner.ToV2())
+	reqBody.SetOwnerID(ownerID.ToV2())
 
 	req := new(v2container.ListRequest)
 	req.SetBody(reqBody)

--- a/pkg/client/container.go
+++ b/pkg/client/container.go
@@ -172,7 +172,7 @@ func (c Client) putContainerV2(ctx context.Context, cnr *container.Container, op
 
 	// if container owner is not set, then use client key as owner
 	if cnr.OwnerID() == nil {
-		w, err := owner.NEO3WalletFromPublicKey(&c.key.PublicKey)
+		w, err := owner.NEO3WalletFromPublicKey(&callOptions.key.PublicKey)
 		if err != nil {
 			return nil, err
 		}
@@ -189,7 +189,7 @@ func (c Client) putContainerV2(ctx context.Context, cnr *container.Container, op
 	// sign container
 	signWrapper := v2signature.StableMarshalerWrapper{SM: reqBody.GetContainer()}
 
-	err := signature.SignDataWithHandler(c.key, signWrapper, func(key []byte, sig []byte) {
+	err := signature.SignDataWithHandler(callOptions.key, signWrapper, func(key []byte, sig []byte) {
 		containerSignature := new(refs.Signature)
 		containerSignature.SetKey(key)
 		containerSignature.SetSign(sig)
@@ -203,7 +203,7 @@ func (c Client) putContainerV2(ctx context.Context, cnr *container.Container, op
 	req.SetBody(reqBody)
 	req.SetMetaHeader(v2MetaHeaderFromOpts(callOptions))
 
-	err = v2signature.SignServiceMessage(c.key, req)
+	err = v2signature.SignServiceMessage(callOptions.key, req)
 	if err != nil {
 		return nil, err
 	}
@@ -246,7 +246,7 @@ func (c Client) getContainerV2(ctx context.Context, id *container.ID, opts ...Ca
 	req.SetBody(reqBody)
 	req.SetMetaHeader(v2MetaHeaderFromOpts(callOptions))
 
-	err := v2signature.SignServiceMessage(c.key, req)
+	err := v2signature.SignServiceMessage(callOptions.key, req)
 	if err != nil {
 		return nil, err
 	}
@@ -283,7 +283,7 @@ func (c Client) listContainerV2(ctx context.Context, ownerID *owner.ID, opts ...
 	}
 
 	if ownerID == nil {
-		w, err := owner.NEO3WalletFromPublicKey(&c.key.PublicKey)
+		w, err := owner.NEO3WalletFromPublicKey(&callOptions.key.PublicKey)
 		if err != nil {
 			return nil, err
 		}
@@ -299,7 +299,7 @@ func (c Client) listContainerV2(ctx context.Context, ownerID *owner.ID, opts ...
 	req.SetBody(reqBody)
 	req.SetMetaHeader(v2MetaHeaderFromOpts(callOptions))
 
-	err := v2signature.SignServiceMessage(c.key, req)
+	err := v2signature.SignServiceMessage(callOptions.key, req)
 	if err != nil {
 		return nil, err
 	}
@@ -344,7 +344,7 @@ func (c Client) delContainerV2(ctx context.Context, id *container.ID, opts ...Ca
 	reqBody.SetContainerID(id.ToV2())
 
 	// sign container
-	err := signature.SignDataWithHandler(c.key,
+	err := signature.SignDataWithHandler(callOptions.key,
 		delContainerSignWrapper{
 			body: reqBody,
 		},
@@ -363,7 +363,7 @@ func (c Client) delContainerV2(ctx context.Context, id *container.ID, opts ...Ca
 	req.SetBody(reqBody)
 	req.SetMetaHeader(v2MetaHeaderFromOpts(callOptions))
 
-	err = v2signature.SignServiceMessage(c.key, req)
+	err = v2signature.SignServiceMessage(callOptions.key, req)
 	if err != nil {
 		return err
 	}
@@ -406,7 +406,7 @@ func (c Client) getEACLV2(ctx context.Context, id *container.ID, verify bool, op
 	req.SetBody(reqBody)
 	req.SetMetaHeader(v2MetaHeaderFromOpts(callOptions))
 
-	err := v2signature.SignServiceMessage(c.key, req)
+	err := v2signature.SignServiceMessage(callOptions.key, req)
 	if err != nil {
 		return nil, err
 	}
@@ -469,7 +469,7 @@ func (c Client) setEACLV2(ctx context.Context, eacl *eacl.Table, opts ...CallOpt
 
 	signWrapper := v2signature.StableMarshalerWrapper{SM: reqBody.GetEACL()}
 
-	err := signature.SignDataWithHandler(c.key, signWrapper, func(key []byte, sig []byte) {
+	err := signature.SignDataWithHandler(callOptions.key, signWrapper, func(key []byte, sig []byte) {
 		eaclSignature := new(refs.Signature)
 		eaclSignature.SetKey(key)
 		eaclSignature.SetSign(sig)
@@ -483,7 +483,7 @@ func (c Client) setEACLV2(ctx context.Context, eacl *eacl.Table, opts ...CallOpt
 	req.SetBody(reqBody)
 	req.SetMetaHeader(v2MetaHeaderFromOpts(callOptions))
 
-	err = v2signature.SignServiceMessage(c.key, req)
+	err = v2signature.SignServiceMessage(callOptions.key, req)
 	if err != nil {
 		return err
 	}
@@ -536,7 +536,7 @@ func (c Client) announceContainerUsedSpaceV2(
 	req.SetMetaHeader(v2MetaHeaderFromOpts(callOptions))
 
 	// sign the request
-	err := v2signature.SignServiceMessage(c.key, req)
+	err := v2signature.SignServiceMessage(callOptions.key, req)
 	if err != nil {
 		return err
 	}

--- a/pkg/client/netmap.go
+++ b/pkg/client/netmap.go
@@ -56,7 +56,7 @@ func (c Client) endpointInfoV2(ctx context.Context, opts ...CallOption) (*v2netm
 	req.SetBody(reqBody)
 	req.SetMetaHeader(v2MetaHeaderFromOpts(callOptions))
 
-	err := v2signature.SignServiceMessage(c.key, req)
+	err := v2signature.SignServiceMessage(callOptions.key, req)
 	if err != nil {
 		return nil, err
 	}
@@ -144,7 +144,7 @@ func (c Client) networkInfoV2(ctx context.Context, opts ...CallOption) (*v2netma
 	req.SetBody(reqBody)
 	req.SetMetaHeader(v2MetaHeaderFromOpts(callOptions))
 
-	err := v2signature.SignServiceMessage(c.key, req)
+	err := v2signature.SignServiceMessage(callOptions.key, req)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/object.go
+++ b/pkg/client/object.go
@@ -254,7 +254,7 @@ func (c *Client) putObjectV2(ctx context.Context, p *PutObjectParams, opts ...Ca
 	initPart.SetHeader(obj.GetHeader())
 
 	// sign the request
-	if err := signature.SignServiceMessage(c.key, req); err != nil {
+	if err := signature.SignServiceMessage(callOpts.key, req); err != nil {
 		return nil, errors.Wrapf(err, "could not sign %T", req)
 	}
 
@@ -274,7 +274,7 @@ func (c *Client) putObjectV2(ctx context.Context, p *PutObjectParams, opts ...Ca
 	body.SetObjectPart(chunkPart)
 
 	w := &putObjectV2Writer{
-		key:       c.key,
+		key:       callOpts.key,
 		chunkPart: chunkPart,
 		req:       req,
 		stream:    stream,
@@ -415,7 +415,7 @@ func (c *Client) deleteObjectV2(ctx context.Context, p *DeleteObjectParams, opts
 	body.SetAddress(p.addr.ToV2())
 
 	// sign the request
-	if err := signature.SignServiceMessage(c.key, req); err != nil {
+	if err := signature.SignServiceMessage(callOpts.key, req); err != nil {
 		return nil, errors.Wrapf(err, "could not sign %T", req)
 	}
 
@@ -529,7 +529,7 @@ func (c *Client) getObjectV2(ctx context.Context, p *GetObjectParams, opts ...Ca
 	body.SetRaw(p.raw)
 
 	// sign the request
-	if err := signature.SignServiceMessage(c.key, req); err != nil {
+	if err := signature.SignServiceMessage(callOpts.key, req); err != nil {
 		return nil, errors.Wrapf(err, "could not sign %T", req)
 	}
 
@@ -702,7 +702,7 @@ func (c *Client) getObjectHeaderV2(ctx context.Context, p *ObjectHeaderParams, o
 	body.SetRaw(p.raw)
 
 	// sign the request
-	if err := signature.SignServiceMessage(c.key, req); err != nil {
+	if err := signature.SignServiceMessage(callOpts.key, req); err != nil {
 		return nil, errors.Wrapf(err, "could not sign %T", req)
 	}
 
@@ -899,7 +899,7 @@ func (c *Client) objectPayloadRangeV2(ctx context.Context, p *RangeDataParams, o
 	body.SetRaw(p.raw)
 
 	// sign the request
-	if err := signature.SignServiceMessage(c.key, req); err != nil {
+	if err := signature.SignServiceMessage(callOpts.key, req); err != nil {
 		return nil, errors.Wrapf(err, "could not sign %T", req)
 	}
 
@@ -1081,7 +1081,7 @@ func (c *Client) objectPayloadRangeHashV2(ctx context.Context, p *RangeChecksumP
 	body.SetRanges(rsV2)
 
 	// sign the request
-	if err := signature.SignServiceMessage(c.key, req); err != nil {
+	if err := signature.SignServiceMessage(callOpts.key, req); err != nil {
 		return nil, errors.Wrapf(err, "could not sign %T", req)
 	}
 
@@ -1228,7 +1228,7 @@ func (c *Client) searchObjectV2(ctx context.Context, p *SearchObjectParams, opts
 	body.SetFilters(p.filters.ToV2())
 
 	// sign the request
-	if err := signature.SignServiceMessage(c.key, req); err != nil {
+	if err := signature.SignServiceMessage(callOpts.key, req); err != nil {
 		return nil, errors.Wrapf(err, "could not sign %T", req)
 	}
 
@@ -1327,7 +1327,7 @@ func (c Client) attachV2SessionToken(opts callOptions, hdr *v2session.RequestMet
 
 	signWrapper := signature.StableMarshalerWrapper{SM: token.GetBody()}
 
-	err := signer.SignDataWithHandler(c.key, signWrapper, func(key []byte, sig []byte) {
+	err := signer.SignDataWithHandler(opts.key, signWrapper, func(key []byte, sig []byte) {
 		sessionTokenSignature := new(v2refs.Signature)
 		sessionTokenSignature.SetKey(key)
 		sessionTokenSignature.SetSign(sig)

--- a/pkg/client/session.go
+++ b/pkg/client/session.go
@@ -30,7 +30,7 @@ func (c Client) createSessionV2(ctx context.Context, expiration uint64, opts ...
 		opts[i].apply(&callOptions)
 	}
 
-	w, err := owner.NEO3WalletFromPublicKey(&c.key.PublicKey)
+	w, err := owner.NEO3WalletFromPublicKey(&callOptions.key.PublicKey)
 	if err != nil {
 		return nil, err
 	}
@@ -46,7 +46,7 @@ func (c Client) createSessionV2(ctx context.Context, expiration uint64, opts ...
 	req.SetBody(reqBody)
 	req.SetMetaHeader(v2MetaHeaderFromOpts(callOptions))
 
-	err = v2signature.SignServiceMessage(c.key, req)
+	err = v2signature.SignServiceMessage(callOptions.key, req)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Close #261 .

Remark about client cache from #261: i think `key` can be fully dropped from the client and provided for each request explicitly. Currently there is (?) possibility for bugs when some of the arguments are taken from client defaults. If cache from nspcc-dev/neofs-node is for connection reuse, key/token stuff should be provided on the other level. Thoughts?