### PR TITLE
pkg/client: Export `Client` interface instead of structure

### DIFF
--- a/pkg/client/accounting.go
+++ b/pkg/client/accounting.go
@@ -11,11 +11,19 @@ import (
 	"github.com/pkg/errors"
 )
 
-func (c Client) GetSelfBalance(ctx context.Context, opts ...CallOption) (*accounting.Decimal, error) {
+// Accounting contains methods related to balance querying.
+type Accounting interface {
+	// GetSelfBalance returns balance of the account deduced from client's key.
+	GetSelfBalance(context.Context, ...CallOption) (*accounting.Decimal, error)
+	// GetBalance returns balance of provided account.
+	GetBalance(context.Context, *owner.ID, ...CallOption) (*accounting.Decimal, error)
+}
+
+func (c clientImpl) GetSelfBalance(ctx context.Context, opts ...CallOption) (*accounting.Decimal, error) {
 	return c.GetBalance(ctx, nil, opts...)
 }
 
-func (c Client) GetBalance(ctx context.Context, owner *owner.ID, opts ...CallOption) (*accounting.Decimal, error) {
+func (c clientImpl) GetBalance(ctx context.Context, owner *owner.ID, opts ...CallOption) (*accounting.Decimal, error) {
 	// check remote node version
 	switch c.remoteNode.Version.Major() {
 	case 2:
@@ -25,7 +33,7 @@ func (c Client) GetBalance(ctx context.Context, owner *owner.ID, opts ...CallOpt
 	}
 }
 
-func (c Client) getBalanceV2(ctx context.Context, ownerID *owner.ID, opts ...CallOption) (*accounting.Decimal, error) {
+func (c clientImpl) getBalanceV2(ctx context.Context, ownerID *owner.ID, opts ...CallOption) (*accounting.Decimal, error) {
 	// apply all available options
 	callOptions := c.defaultCallOptions()
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -9,7 +9,16 @@ import (
 )
 
 type (
-	Client struct {
+	// Client represents NeoFS client.
+	Client interface {
+		Accounting
+		Container
+		Netmap
+		Object
+		Session
+	}
+
+	clientImpl struct {
 		key        *ecdsa.PrivateKey
 		remoteNode TransportInfo
 
@@ -35,7 +44,8 @@ const (
 
 var errUnsupportedProtocol = errors.New("unsupported transport protocol")
 
-func New(key *ecdsa.PrivateKey, opts ...Option) (*Client, error) {
+// New returns new client which uses key as default signing key.
+func New(key *ecdsa.PrivateKey, opts ...Option) (Client, error) {
 	clientOptions := defaultClientOptions()
 
 	for i := range opts {
@@ -43,7 +53,7 @@ func New(key *ecdsa.PrivateKey, opts ...Option) (*Client, error) {
 	}
 
 	// todo: make handshake to check latest version
-	return &Client{
+	return &clientImpl{
 		key: key,
 		remoteNode: TransportInfo{
 			Version:  pkg.SDKVersion(),

--- a/pkg/client/netmap.go
+++ b/pkg/client/netmap.go
@@ -10,10 +10,22 @@ import (
 	"github.com/pkg/errors"
 )
 
+// Netmap contains methods related to netmap.
+type Netmap interface {
+	// EndpointInfo returns attributes, address and public key of the node, specified
+	// in client constructor via address or open connection. This can be used as a
+	// health check to see if node is alive and responses to requests.
+	EndpointInfo(context.Context, ...CallOption) (*netmap.NodeInfo, error)
+	// Epoch returns the epoch number from the local state of the remote host.
+	Epoch(context.Context, ...CallOption) (uint64, error)
+	// NetworkInfo returns information about the NeoFS network of which the remote server is a part.
+	NetworkInfo(context.Context, ...CallOption) (*netmap.NetworkInfo, error)
+}
+
 // EndpointInfo returns attributes, address and public key of the node, specified
 // in client constructor via address or open connection. This can be used as a
 // health check to see if node is alive and responses to requests.
-func (c Client) EndpointInfo(ctx context.Context, opts ...CallOption) (*netmap.NodeInfo, error) {
+func (c clientImpl) EndpointInfo(ctx context.Context, opts ...CallOption) (*netmap.NodeInfo, error) {
 	switch c.remoteNode.Version.Major() {
 	case 2:
 		resp, err := c.endpointInfoV2(ctx, opts...)
@@ -28,7 +40,7 @@ func (c Client) EndpointInfo(ctx context.Context, opts ...CallOption) (*netmap.N
 }
 
 // Epoch returns the epoch number from the local state of the remote host.
-func (c Client) Epoch(ctx context.Context, opts ...CallOption) (uint64, error) {
+func (c clientImpl) Epoch(ctx context.Context, opts ...CallOption) (uint64, error) {
 	switch c.remoteNode.Version.Major() {
 	case 2:
 		resp, err := c.endpointInfoV2(ctx, opts...)
@@ -42,7 +54,7 @@ func (c Client) Epoch(ctx context.Context, opts ...CallOption) (uint64, error) {
 	}
 }
 
-func (c Client) endpointInfoV2(ctx context.Context, opts ...CallOption) (*v2netmap.LocalNodeInfoResponse, error) {
+func (c clientImpl) endpointInfoV2(ctx context.Context, opts ...CallOption) (*v2netmap.LocalNodeInfoResponse, error) {
 	// apply all available options
 	callOptions := c.defaultCallOptions()
 
@@ -116,7 +128,7 @@ func v2NetmapClientFromOptions(opts *clientOptions) (cli *v2netmap.Client, err e
 }
 
 // NetworkInfo returns information about the NeoFS network of which the remote server is a part.
-func (c Client) NetworkInfo(ctx context.Context, opts ...CallOption) (*netmap.NetworkInfo, error) {
+func (c clientImpl) NetworkInfo(ctx context.Context, opts ...CallOption) (*netmap.NetworkInfo, error) {
 	switch c.remoteNode.Version.Major() {
 	case 2:
 		resp, err := c.networkInfoV2(ctx, opts...)
@@ -130,7 +142,7 @@ func (c Client) NetworkInfo(ctx context.Context, opts ...CallOption) (*netmap.Ne
 	}
 }
 
-func (c Client) networkInfoV2(ctx context.Context, opts ...CallOption) (*v2netmap.NetworkInfoResponse, error) {
+func (c clientImpl) networkInfoV2(ctx context.Context, opts ...CallOption) (*v2netmap.NetworkInfoResponse, error) {
 	// apply all available options
 	callOptions := c.defaultCallOptions()
 

--- a/pkg/client/opts.go
+++ b/pkg/client/opts.go
@@ -68,7 +68,7 @@ func (e errOptionsLack) Error() string {
 	return fmt.Sprintf("lack of sdk client options to create %s client", string(e))
 }
 
-func (c Client) defaultCallOptions() callOptions {
+func (c clientImpl) defaultCallOptions() callOptions {
 	return callOptions{
 		ttl:     2,
 		version: pkg.SDKVersion(),

--- a/pkg/client/session.go
+++ b/pkg/client/session.go
@@ -11,9 +11,19 @@ import (
 	"github.com/pkg/errors"
 )
 
+// Session contains session-related methods.
+type Session interface {
+	// CreateSession creates session using provided expiration time.
+	CreateSession(context.Context, uint64, ...CallOption) (*token.SessionToken, error)
+	// AttachSessionToken attaches session token to be used by default for following requests.
+	AttachSessionToken(*token.SessionToken)
+	// AttachBearerToken attaches bearer token to be used by default for following requests.
+	AttachBearerToken(*token.BearerToken)
+}
+
 var errMalformedResponseBody = errors.New("malformed response body")
 
-func (c Client) CreateSession(ctx context.Context, expiration uint64, opts ...CallOption) (*token.SessionToken, error) {
+func (c clientImpl) CreateSession(ctx context.Context, expiration uint64, opts ...CallOption) (*token.SessionToken, error) {
 	switch c.remoteNode.Version.Major() {
 	case 2:
 		return c.createSessionV2(ctx, expiration, opts...)
@@ -22,7 +32,7 @@ func (c Client) CreateSession(ctx context.Context, expiration uint64, opts ...Ca
 	}
 }
 
-func (c Client) createSessionV2(ctx context.Context, expiration uint64, opts ...CallOption) (*token.SessionToken, error) {
+func (c clientImpl) createSessionV2(ctx context.Context, expiration uint64, opts ...CallOption) (*token.SessionToken, error) {
 	// apply all available options
 	callOptions := c.defaultCallOptions()
 
@@ -119,7 +129,7 @@ func v2SessionClientFromOptions(opts *clientOptions) (cli *v2session.Client, err
 //
 // Provided token is attached to all requests without WithSession option.
 // Use WithSession(nil) option in order to send request without session token.
-func (c *Client) AttachSessionToken(token *token.SessionToken) {
+func (c *clientImpl) AttachSessionToken(token *token.SessionToken) {
 	c.sessionToken = token
 }
 
@@ -127,6 +137,6 @@ func (c *Client) AttachSessionToken(token *token.SessionToken) {
 //
 // Provided bearer is attached to all requests without WithBearer option.
 // Use WithBearer(nil) option in order to send request without bearer token.
-func (c *Client) AttachBearerToken(token *token.BearerToken) {
+func (c *clientImpl) AttachBearerToken(token *token.BearerToken) {
 	c.bearerToken = token
 }


### PR DESCRIPTION
Make it easier to test client API and mock specific methods. Can help to remove some wrappers from nspcc-dev/neofs-node (it can already be done, but changing tests is harder).
Also add comments on exported methods.

This interferes with #263, but not a lot.