### PR TITLE
Bug/Add nil check

### DIFF
--- a/v2/reputation/convert.go
+++ b/v2/reputation/convert.go
@@ -476,9 +476,18 @@ func (x *SendIntermediateResultRequestBody) FromGRPCMessage(m grpc.Message) erro
 		return message.NewUnexpectedMessageType(m, v)
 	}
 
-	err := x.trust.FromGRPCMessage(v.GetTrust())
-	if err != nil {
-		return err
+	trust := v.GetTrust()
+	if trust == nil {
+		x.trust = nil
+	} else {
+		if x.trust == nil {
+			x.trust = new(PeerToPeerTrust)
+		}
+
+		err := x.trust.FromGRPCMessage(trust)
+		if err != nil {
+			return err
+		}
 	}
 
 	x.epoch = v.GetEpoch()

--- a/v2/reputation/test/generate.go
+++ b/v2/reputation/test/generate.go
@@ -111,9 +111,8 @@ func GenerateSendIntermediateResultRequestBody(empty bool) *reputation.SendInter
 	if !empty {
 		m.SetEpoch(123)
 		m.SetIteration(564)
+		m.SetTrust(GeneratePeerToPeerTrust(empty))
 	}
-
-	m.SetTrust(GeneratePeerToPeerTrust(empty))
 
 	return m
 }


### PR DESCRIPTION
In `SendIntermediateResultRequestBody` add nil check for `trust` field.
If true, allocate new `PeerToPeerTrust`.

Move allocation of new `PeerToPeerTrust` in unit test to `if !empty` statement => now that test covers bug case.