### PR TITLE
pkg/client: Fix payload slice allocation in Object Range method

### DIFF
--- a/pkg/client/object.go
+++ b/pkg/client/object.go
@@ -874,7 +874,7 @@ func (c *clientImpl) ObjectPayloadRangeData(ctx context.Context, p *RangeDataPar
 
 	var payload []byte
 	if p.w != nil {
-		payload = make([]byte, p.r.GetLength())
+		payload = make([]byte, 0, p.r.GetLength())
 	}
 
 	resp := new(v2object.GetRangeResponse)


### PR DESCRIPTION
Allocate capacity instead of length of the slice to write the object payload
range since each chunk is written through `append`.

Signed-off-by: Leonard Lyubich <leonard@nspcc.ru>