### PR TITLE
[#277] go.mod: remove `pkg/errors`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/nspcc-dev/hrw v1.0.9
 	github.com/nspcc-dev/neo-go v0.95.0
 	github.com/nspcc-dev/neofs-crypto v0.3.0
-	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.6.1
 	google.golang.org/grpc v1.29.1
 	google.golang.org/protobuf v1.23.0

--- a/pkg/checksum.go
+++ b/pkg/checksum.go
@@ -4,9 +4,9 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
+	"fmt"
 
 	"github.com/nspcc-dev/neofs-api-go/v2/refs"
-	"github.com/pkg/errors"
 )
 
 // Checksum represents v2-compatible checksum.
@@ -130,7 +130,7 @@ func (c *Checksum) Parse(s string) error {
 
 	switch ln := len(data); ln {
 	default:
-		return errors.Errorf("unsupported checksum length %d", ln)
+		return fmt.Errorf("unsupported checksum length %d", ln)
 	case sha256.Size:
 		typ = refs.SHA256
 	case 64:

--- a/pkg/client/accounting.go
+++ b/pkg/client/accounting.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/nspcc-dev/neofs-api-go/pkg/accounting"
 	"github.com/nspcc-dev/neofs-api-go/pkg/owner"
@@ -9,7 +10,6 @@ import (
 	v2accounting "github.com/nspcc-dev/neofs-api-go/v2/accounting"
 	rpcapi "github.com/nspcc-dev/neofs-api-go/v2/rpc"
 	v2signature "github.com/nspcc-dev/neofs-api-go/v2/signature"
-	"github.com/pkg/errors"
 )
 
 // Accounting contains methods related to balance querying.
@@ -40,12 +40,12 @@ func (c *clientImpl) GetBalance(ctx context.Context, owner *owner.ID, opts ...Ca
 
 	resp, err := rpcapi.Balance(c.Raw(), req, client.WithContext(ctx))
 	if err != nil {
-		return nil, errors.Wrap(err, "transport error")
+		return nil, fmt.Errorf("transport error: %w", err)
 	}
 
 	err = v2signature.VerifyServiceMessage(resp)
 	if err != nil {
-		return nil, errors.Wrap(err, "can't verify response message")
+		return nil, fmt.Errorf("can't verify response message: %w", err)
 	}
 
 	return accounting.NewDecimalFromV2(resp.GetBody().GetBalance()), nil

--- a/pkg/client/container.go
+++ b/pkg/client/container.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/nspcc-dev/neofs-api-go/pkg"
 	"github.com/nspcc-dev/neofs-api-go/pkg/acl/eacl"
@@ -13,7 +14,6 @@ import (
 	"github.com/nspcc-dev/neofs-api-go/v2/refs"
 	rpcapi "github.com/nspcc-dev/neofs-api-go/v2/rpc"
 	v2signature "github.com/nspcc-dev/neofs-api-go/v2/signature"
-	"github.com/pkg/errors"
 )
 
 // Container contains methods related to container and ACL.
@@ -125,7 +125,7 @@ func (c *clientImpl) PutContainer(ctx context.Context, cnr *container.Container,
 
 	err = v2signature.VerifyServiceMessage(resp)
 	if err != nil {
-		return nil, errors.Wrap(err, "can't verify response message")
+		return nil, fmt.Errorf("can't verify response message: %w", err)
 	}
 
 	return container.NewIDFromV2(resp.GetBody().GetContainerID()), nil
@@ -156,12 +156,12 @@ func (c *clientImpl) GetContainer(ctx context.Context, id *container.ID, opts ..
 
 	resp, err := rpcapi.GetContainer(c.Raw(), req, client.WithContext(ctx))
 	if err != nil {
-		return nil, errors.Wrap(err, "transport error")
+		return nil, fmt.Errorf("transport error: %w", err)
 	}
 
 	err = v2signature.VerifyServiceMessage(resp)
 	if err != nil {
-		return nil, errors.Wrap(err, "can't verify response message")
+		return nil, fmt.Errorf("can't verify response message: %w", err)
 	}
 
 	return container.NewVerifiedFromV2(resp.GetBody().GetContainer())
@@ -216,12 +216,12 @@ func (c *clientImpl) ListContainers(ctx context.Context, ownerID *owner.ID, opts
 
 	resp, err := rpcapi.ListContainers(c.Raw(), req, client.WithContext(ctx))
 	if err != nil {
-		return nil, errors.Wrap(err, "transport error")
+		return nil, fmt.Errorf("transport error: %w", err)
 	}
 
 	err = v2signature.VerifyServiceMessage(resp)
 	if err != nil {
-		return nil, errors.Wrap(err, "can't verify response message")
+		return nil, fmt.Errorf("can't verify response message: %w", err)
 	}
 
 	result := make([]*container.ID, 0, len(resp.GetBody().GetContainerIDs()))
@@ -270,10 +270,14 @@ func (c *clientImpl) DeleteContainer(ctx context.Context, id *container.ID, opts
 
 	resp, err := rpcapi.DeleteContainer(c.Raw(), req, client.WithContext(ctx))
 	if err != nil {
-		return errors.Wrap(err, "transport error")
+		return fmt.Errorf("transport error: %w", err)
 	}
 
-	return errors.Wrap(v2signature.VerifyServiceMessage(resp), "can't verify response message")
+	if err := v2signature.VerifyServiceMessage(resp); err != nil {
+		return fmt.Errorf("can't verify response message: %w", err)
+	}
+
+	return nil
 }
 
 func (c *clientImpl) GetEACL(ctx context.Context, id *container.ID, opts ...CallOption) (*EACLWithSignature, error) {
@@ -298,12 +302,12 @@ func (c *clientImpl) GetEACL(ctx context.Context, id *container.ID, opts ...Call
 
 	resp, err := rpcapi.GetEACL(c.Raw(), req, client.WithContext(ctx))
 	if err != nil {
-		return nil, errors.Wrap(err, "transport error")
+		return nil, fmt.Errorf("transport error: %w", err)
 	}
 
 	err = v2signature.VerifyServiceMessage(resp)
 	if err != nil {
-		return nil, errors.Wrap(err, "can't verify response message")
+		return nil, fmt.Errorf("can't verify response message: %w", err)
 	}
 
 	body := resp.GetBody()
@@ -349,12 +353,12 @@ func (c *clientImpl) SetEACL(ctx context.Context, eacl *eacl.Table, opts ...Call
 
 	resp, err := rpcapi.SetEACL(c.Raw(), req, client.WithContext(ctx))
 	if err != nil {
-		return errors.Wrap(err, "transport error")
+		return fmt.Errorf("transport error: %w", err)
 	}
 
 	err = v2signature.VerifyServiceMessage(resp)
 	if err != nil {
-		return errors.Wrap(err, "can't verify response message")
+		return fmt.Errorf("can't verify response message: %w", err)
 	}
 
 	return nil
@@ -394,12 +398,12 @@ func (c *clientImpl) AnnounceContainerUsedSpace(
 
 	resp, err := rpcapi.AnnounceUsedSpace(c.Raw(), req, client.WithContext(ctx))
 	if err != nil {
-		return errors.Wrap(err, "transport error")
+		return fmt.Errorf("transport error: %w", err)
 	}
 
 	err = v2signature.VerifyServiceMessage(resp)
 	if err != nil {
-		return errors.Wrap(err, "can't verify response message")
+		return fmt.Errorf("can't verify response message: %w", err)
 	}
 
 	return nil

--- a/pkg/client/netmap.go
+++ b/pkg/client/netmap.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/nspcc-dev/neofs-api-go/pkg"
 	"github.com/nspcc-dev/neofs-api-go/pkg/netmap"
@@ -9,7 +10,6 @@ import (
 	v2netmap "github.com/nspcc-dev/neofs-api-go/v2/netmap"
 	rpcapi "github.com/nspcc-dev/neofs-api-go/v2/rpc"
 	v2signature "github.com/nspcc-dev/neofs-api-go/v2/signature"
-	"github.com/pkg/errors"
 )
 
 // Netmap contains methods related to netmap.
@@ -64,12 +64,12 @@ func (c *clientImpl) EndpointInfo(ctx context.Context, opts ...CallOption) (*End
 
 	resp, err := rpcapi.LocalNodeInfo(c.Raw(), req)
 	if err != nil {
-		return nil, errors.Wrap(err, "transport error")
+		return nil, fmt.Errorf("transport error: %w", err)
 	}
 
 	err = v2signature.VerifyServiceMessage(resp)
 	if err != nil {
-		return nil, errors.Wrap(err, "can't verify response message")
+		return nil, fmt.Errorf("can't verify response message: %w", err)
 	}
 
 	body := resp.GetBody()
@@ -102,12 +102,12 @@ func (c *clientImpl) NetworkInfo(ctx context.Context, opts ...CallOption) (*netm
 
 	resp, err := rpcapi.NetworkInfo(c.Raw(), req, client.WithContext(ctx))
 	if err != nil {
-		return nil, errors.Wrap(err, "v2 NetworkInfo RPC failure")
+		return nil, fmt.Errorf("v2 NetworkInfo RPC failure: %w", err)
 	}
 
 	err = v2signature.VerifyServiceMessage(resp)
 	if err != nil {
-		return nil, errors.Wrap(err, "response message verification failed")
+		return nil, fmt.Errorf("response message verification failed: %w", err)
 	}
 
 	return netmap.NewNetworkInfoFromV2(resp.GetBody().GetNetworkInfo()), nil

--- a/pkg/client/reputation.go
+++ b/pkg/client/reputation.go
@@ -2,13 +2,13 @@ package client
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/nspcc-dev/neofs-api-go/pkg/reputation"
 	"github.com/nspcc-dev/neofs-api-go/rpc/client"
 	v2reputation "github.com/nspcc-dev/neofs-api-go/v2/reputation"
 	rpcapi "github.com/nspcc-dev/neofs-api-go/v2/rpc"
 	v2signature "github.com/nspcc-dev/neofs-api-go/v2/signature"
-	"github.com/pkg/errors"
 )
 
 // Reputation contains methods for working with Reputation system values.
@@ -79,7 +79,7 @@ func (c *clientImpl) AnnounceLocalTrust(ctx context.Context, prm AnnounceLocalTr
 
 	err = v2signature.VerifyServiceMessage(resp)
 	if err != nil {
-		return nil, errors.Wrap(err, "can't verify response message")
+		return nil, fmt.Errorf("can't verify response message: %w", err)
 	}
 
 	return new(AnnounceLocalTrustRes), nil
@@ -154,7 +154,7 @@ func (c *clientImpl) AnnounceIntermediateTrust(ctx context.Context, prm Announce
 
 	err = v2signature.VerifyServiceMessage(resp)
 	if err != nil {
-		return nil, errors.Wrap(err, "can't verify response message")
+		return nil, fmt.Errorf("can't verify response message: %w", err)
 	}
 
 	return new(AnnounceIntermediateTrustRes), nil

--- a/pkg/client/session.go
+++ b/pkg/client/session.go
@@ -2,6 +2,8 @@ package client
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
 	"github.com/nspcc-dev/neofs-api-go/pkg/owner"
 	"github.com/nspcc-dev/neofs-api-go/pkg/token"
@@ -9,7 +11,6 @@ import (
 	rpcapi "github.com/nspcc-dev/neofs-api-go/v2/rpc"
 	v2session "github.com/nspcc-dev/neofs-api-go/v2/session"
 	v2signature "github.com/nspcc-dev/neofs-api-go/v2/signature"
-	"github.com/pkg/errors"
 )
 
 // Session contains session-related methods.
@@ -51,12 +52,12 @@ func (c *clientImpl) CreateSession(ctx context.Context, expiration uint64, opts 
 
 	resp, err := rpcapi.CreateSession(c.Raw(), req, client.WithContext(ctx))
 	if err != nil {
-		return nil, errors.Wrap(err, "transport error")
+		return nil, fmt.Errorf("transport error: %w", err)
 	}
 
 	err = v2signature.VerifyServiceMessage(resp)
 	if err != nil {
-		return nil, errors.Wrap(err, "can't verify response message")
+		return nil, fmt.Errorf("can't verify response message: %w", err)
 	}
 
 	body := resp.GetBody()

--- a/pkg/container/fmt.go
+++ b/pkg/container/fmt.go
@@ -1,9 +1,10 @@
 package container
 
 import (
+	"fmt"
+
 	"github.com/nspcc-dev/neofs-api-go/pkg"
 	"github.com/nspcc-dev/neofs-api-go/v2/container"
-	"github.com/pkg/errors"
 )
 
 // NewVerifiedFromV2 constructs Container from NeoFS API V2 Container message.
@@ -20,7 +21,7 @@ func NewVerifiedFromV2(cnrV2 *container.Container) (*Container, error) {
 
 	// check nonce format
 	if _, err := cnr.NonceUUID(); err != nil {
-		return nil, errors.Wrap(err, "invalid nonce")
+		return nil, fmt.Errorf("invalid nonce: %w", err)
 	}
 
 	return cnr, nil

--- a/pkg/container/id.go
+++ b/pkg/container/id.go
@@ -3,10 +3,11 @@ package container
 import (
 	"bytes"
 	"crypto/sha256"
+	"errors"
+	"fmt"
 
 	"github.com/mr-tron/base58"
 	"github.com/nspcc-dev/neofs-api-go/v2/refs"
-	"github.com/pkg/errors"
 )
 
 // ID represents v2-compatible container identifier.
@@ -52,7 +53,7 @@ func (id *ID) Equal(id2 *ID) bool {
 func (id *ID) Parse(s string) error {
 	data, err := base58.Decode(s)
 	if err != nil {
-		return errors.Wrap(err, "could not parse container.ID from string")
+		return fmt.Errorf("could not parse container.ID from string: %w", err)
 	} else if len(data) != sha256.Size {
 		return errInvalidIDString
 	}

--- a/pkg/object/fmt.go
+++ b/pkg/object/fmt.go
@@ -3,11 +3,12 @@ package object
 import (
 	"crypto/ecdsa"
 	"crypto/sha256"
+	"errors"
+	"fmt"
 
 	"github.com/nspcc-dev/neofs-api-go/pkg"
 	"github.com/nspcc-dev/neofs-api-go/util/signature"
 	signatureV2 "github.com/nspcc-dev/neofs-api-go/v2/signature"
-	"github.com/pkg/errors"
 )
 
 var errCheckSumMismatch = errors.New("payload checksum mismatch")
@@ -131,11 +132,11 @@ func VerifyIDSignature(obj *Object) error {
 // SetIDWithSignature sets object identifier and signature.
 func SetIDWithSignature(key *ecdsa.PrivateKey, obj *RawObject) error {
 	if err := CalculateAndSetID(obj); err != nil {
-		return errors.Wrap(err, "could not set identifier")
+		return fmt.Errorf("could not set identifier: %w", err)
 	}
 
 	if err := CalculateAndSetSignature(key, obj); err != nil {
-		return errors.Wrap(err, "could not set signature")
+		return fmt.Errorf("could not set signature: %w", err)
 	}
 
 	return nil
@@ -151,11 +152,11 @@ func SetVerificationFields(key *ecdsa.PrivateKey, obj *RawObject) error {
 // CheckVerificationFields checks all verification fields of the object.
 func CheckVerificationFields(obj *Object) error {
 	if err := CheckHeaderVerificationFields(obj); err != nil {
-		return errors.Wrap(err, "invalid header structure")
+		return fmt.Errorf("invalid header structure: %w", err)
 	}
 
 	if err := VerifyPayloadChecksum(obj); err != nil {
-		return errors.Wrap(err, "invalid payload checksum")
+		return fmt.Errorf("invalid payload checksum: %w", err)
 	}
 
 	return nil
@@ -164,11 +165,11 @@ func CheckVerificationFields(obj *Object) error {
 // CheckHeaderVerificationFields checks all verification fields except payload.
 func CheckHeaderVerificationFields(obj *Object) error {
 	if err := VerifyIDSignature(obj); err != nil {
-		return errors.Wrap(err, "invalid signature")
+		return fmt.Errorf("invalid signature: %w", err)
 	}
 
 	if err := VerifyID(obj); err != nil {
-		return errors.Wrap(err, "invalid identifier")
+		return fmt.Errorf("invalid identifier: %w", err)
 	}
 
 	return nil

--- a/pkg/object/id.go
+++ b/pkg/object/id.go
@@ -3,10 +3,11 @@ package object
 import (
 	"bytes"
 	"crypto/sha256"
+	"errors"
+	"fmt"
 
 	"github.com/mr-tron/base58"
 	"github.com/nspcc-dev/neofs-api-go/v2/refs"
-	"github.com/pkg/errors"
 )
 
 // ID represents v2-compatible object identifier.
@@ -48,7 +49,7 @@ func (id *ID) ToV2() *refs.ObjectID {
 func (id *ID) Parse(s string) error {
 	data, err := base58.Decode(s)
 	if err != nil {
-		return errors.Wrap(err, "could not parse object.ID from string")
+		return fmt.Errorf("could not parse object.ID from string: %w", err)
 	} else if len(data) != sha256.Size {
 		return errInvalidIDString
 	}

--- a/pkg/owner/id.go
+++ b/pkg/owner/id.go
@@ -1,12 +1,12 @@
 package owner
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/mr-tron/base58"
 	"github.com/nspcc-dev/neo-go/pkg/encoding/address"
 	"github.com/nspcc-dev/neofs-api-go/v2/refs"
-	"github.com/pkg/errors"
 )
 
 // ID represents v2-compatible owner identifier.
@@ -61,7 +61,7 @@ func NewIDFromNeo3Wallet(v *NEO3Wallet) *ID {
 func (id *ID) Parse(s string) error {
 	data, err := base58.Decode(s)
 	if err != nil {
-		return errors.Wrap(err, "could not parse owner.ID from string")
+		return fmt.Errorf("could not parse owner.ID from string: %w", err)
 	} else if len(data) != NEO3WalletSize {
 		return errInvalidIDString
 	}

--- a/pkg/owner/wallet.go
+++ b/pkg/owner/wallet.go
@@ -2,11 +2,11 @@ package owner
 
 import (
 	"crypto/ecdsa"
+	"fmt"
 
 	"github.com/mr-tron/base58"
 	"github.com/nspcc-dev/neo-go/pkg/crypto/keys"
 	crypto "github.com/nspcc-dev/neofs-crypto"
-	"github.com/pkg/errors"
 )
 
 // NEO3Wallet represents NEO3 wallet address.
@@ -28,7 +28,7 @@ func NEO3WalletFromPublicKey(key *ecdsa.PublicKey) (*NEO3Wallet, error) {
 
 	d, err := base58.Decode(neoPublicKey.Address())
 	if err != nil {
-		return nil, errors.Wrap(err, "can't decode neo3 address from key")
+		return nil, fmt.Errorf("can't decode neo3 address from key: %w", err)
 	}
 
 	w := new(NEO3Wallet)

--- a/pkg/version.go
+++ b/pkg/version.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/nspcc-dev/neofs-api-go/v2/refs"
-	"github.com/pkg/errors"
 )
 
 // Version represents v2-compatible version.
@@ -72,7 +71,7 @@ func IsSupportedVersion(v *Version) error {
 	mjr, mnr := v.Major(), v.Minor()
 
 	if mjr != 2 || mnr > sdkMnr {
-		return errors.Errorf("unsupported version %d.%d", mjr, mnr)
+		return fmt.Errorf("unsupported version %d.%d", mjr, mnr)
 	}
 
 	return nil

--- a/rpc/client/flows.go
+++ b/rpc/client/flows.go
@@ -1,12 +1,12 @@
 package client
 
 import (
+	"errors"
 	"io"
 	"sync"
 
 	"github.com/nspcc-dev/neofs-api-go/rpc/common"
 	"github.com/nspcc-dev/neofs-api-go/rpc/message"
-	"github.com/pkg/errors"
 )
 
 // SendUnary initializes communication session by RPC info, performs unary RPC

--- a/rpc/message/test/message.go
+++ b/rpc/message/test/message.go
@@ -2,11 +2,11 @@ package messagetest
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"testing"
 
 	"github.com/nspcc-dev/neofs-api-go/rpc/message"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 )
 

--- a/util/proto/marshal_test.go
+++ b/util/proto/marshal_test.go
@@ -1,12 +1,12 @@
 package proto_test
 
 import (
+	"fmt"
 	"math"
 	"testing"
 
 	"github.com/nspcc-dev/neofs-api-go/util/proto"
 	"github.com/nspcc-dev/neofs-api-go/util/proto/test"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	goproto "google.golang.org/protobuf/proto"
 )
@@ -60,7 +60,7 @@ func (s *stablePrimitives) stableMarshal(buf []byte, wrongField bool) ([]byte, e
 	}
 	offset, err := proto.BytesMarshal(fieldNum, buf, s.FieldA)
 	if err != nil {
-		return nil, errors.Wrap(err, "can't marshal field a")
+		return nil, fmt.Errorf("can't marshal field a: %w", err)
 	}
 	i += offset
 
@@ -70,7 +70,7 @@ func (s *stablePrimitives) stableMarshal(buf []byte, wrongField bool) ([]byte, e
 	}
 	offset, err = proto.StringMarshal(fieldNum, buf, s.FieldB)
 	if err != nil {
-		return nil, errors.Wrap(err, "can't marshal field b")
+		return nil, fmt.Errorf("can't marshal field b: %w", err)
 	}
 	i += offset
 
@@ -80,7 +80,7 @@ func (s *stablePrimitives) stableMarshal(buf []byte, wrongField bool) ([]byte, e
 	}
 	offset, err = proto.BoolMarshal(fieldNum, buf, s.FieldC)
 	if err != nil {
-		return nil, errors.Wrap(err, "can't marshal field c")
+		return nil, fmt.Errorf("can't marshal field c: %w", err)
 	}
 	i += offset
 
@@ -90,7 +90,7 @@ func (s *stablePrimitives) stableMarshal(buf []byte, wrongField bool) ([]byte, e
 	}
 	offset, err = proto.Int32Marshal(fieldNum, buf, s.FieldD)
 	if err != nil {
-		return nil, errors.Wrap(err, "can't marshal field d")
+		return nil, fmt.Errorf("can't marshal field d: %w", err)
 	}
 	i += offset
 
@@ -100,7 +100,7 @@ func (s *stablePrimitives) stableMarshal(buf []byte, wrongField bool) ([]byte, e
 	}
 	offset, err = proto.UInt32Marshal(fieldNum, buf, s.FieldE)
 	if err != nil {
-		return nil, errors.Wrap(err, "can't marshal field e")
+		return nil, fmt.Errorf("can't marshal field e: %w", err)
 	}
 	i += offset
 
@@ -110,7 +110,7 @@ func (s *stablePrimitives) stableMarshal(buf []byte, wrongField bool) ([]byte, e
 	}
 	offset, err = proto.Int64Marshal(fieldNum, buf, s.FieldF)
 	if err != nil {
-		return nil, errors.Wrap(err, "can't marshal field f")
+		return nil, fmt.Errorf("can't marshal field f: %w", err)
 	}
 	i += offset
 
@@ -120,7 +120,7 @@ func (s *stablePrimitives) stableMarshal(buf []byte, wrongField bool) ([]byte, e
 	}
 	offset, err = proto.UInt64Marshal(fieldNum, buf, s.FieldG)
 	if err != nil {
-		return nil, errors.Wrap(err, "can't marshal field g")
+		return nil, fmt.Errorf("can't marshal field g: %w", err)
 	}
 	i += offset
 
@@ -130,7 +130,7 @@ func (s *stablePrimitives) stableMarshal(buf []byte, wrongField bool) ([]byte, e
 	}
 	offset, err = proto.Fixed64Marshal(fieldNum, buf, s.FieldI)
 	if err != nil {
-		return nil, errors.Wrap(err, "can't marshal field I")
+		return nil, fmt.Errorf("can't marshal field I: %w", err)
 	}
 	i += offset
 
@@ -140,7 +140,7 @@ func (s *stablePrimitives) stableMarshal(buf []byte, wrongField bool) ([]byte, e
 	}
 	offset, err = proto.Float64Marshal(fieldNum, buf, s.FieldJ)
 	if err != nil {
-		return nil, errors.Wrap(err, "can't marshal field J")
+		return nil, fmt.Errorf("can't marshal field J: %w", err)
 	}
 	i += offset
 
@@ -150,7 +150,7 @@ func (s *stablePrimitives) stableMarshal(buf []byte, wrongField bool) ([]byte, e
 	}
 	offset, err = proto.EnumMarshal(fieldNum, buf, int32(s.FieldH))
 	if err != nil {
-		return nil, errors.Wrap(err, "can't marshal field h")
+		return nil, fmt.Errorf("can't marshal field h: %w", err)
 	}
 	i += offset
 
@@ -189,7 +189,7 @@ func (s *stableRepPrimitives) stableMarshal(buf []byte, wrongField bool) ([]byte
 	}
 	offset, err := proto.RepeatedBytesMarshal(fieldNum, buf, s.FieldA)
 	if err != nil {
-		return nil, errors.Wrap(err, "can't marshal field a")
+		return nil, fmt.Errorf("can't marshal field a: %w", err)
 	}
 	i += offset
 
@@ -199,7 +199,7 @@ func (s *stableRepPrimitives) stableMarshal(buf []byte, wrongField bool) ([]byte
 	}
 	offset, err = proto.RepeatedStringMarshal(fieldNum, buf, s.FieldB)
 	if err != nil {
-		return nil, errors.Wrap(err, "can't marshal field b")
+		return nil, fmt.Errorf("can't marshal field b: %w", err)
 	}
 	i += offset
 
@@ -209,7 +209,7 @@ func (s *stableRepPrimitives) stableMarshal(buf []byte, wrongField bool) ([]byte
 	}
 	offset, err = proto.RepeatedInt32Marshal(fieldNum, buf, s.FieldC)
 	if err != nil {
-		return nil, errors.Wrap(err, "can't marshal field c")
+		return nil, fmt.Errorf("can't marshal field c: %w", err)
 	}
 	i += offset
 
@@ -219,7 +219,7 @@ func (s *stableRepPrimitives) stableMarshal(buf []byte, wrongField bool) ([]byte
 	}
 	offset, err = proto.RepeatedUInt32Marshal(fieldNum, buf, s.FieldD)
 	if err != nil {
-		return nil, errors.Wrap(err, "can't marshal field d")
+		return nil, fmt.Errorf("can't marshal field d: %w", err)
 	}
 	i += offset
 
@@ -229,7 +229,7 @@ func (s *stableRepPrimitives) stableMarshal(buf []byte, wrongField bool) ([]byte
 	}
 	offset, err = proto.RepeatedInt64Marshal(fieldNum, buf, s.FieldE)
 	if err != nil {
-		return nil, errors.Wrap(err, "can't marshal field e")
+		return nil, fmt.Errorf("can't marshal field e: %w", err)
 	}
 	i += offset
 
@@ -239,7 +239,7 @@ func (s *stableRepPrimitives) stableMarshal(buf []byte, wrongField bool) ([]byte
 	}
 	offset, err = proto.RepeatedUInt64Marshal(fieldNum, buf, s.FieldF)
 	if err != nil {
-		return nil, errors.Wrap(err, "can't marshal field f")
+		return nil, fmt.Errorf("can't marshal field f: %w", err)
 	}
 	i += offset
 

--- a/util/signature/util.go
+++ b/util/signature/util.go
@@ -1,9 +1,8 @@
 package signature
 
 import (
+	"errors"
 	"sync"
-
-	"github.com/pkg/errors"
 )
 
 var bytesPool = sync.Pool{

--- a/v2/object/convert.go
+++ b/v2/object/convert.go
@@ -10,7 +10,6 @@ import (
 	refsGRPC "github.com/nspcc-dev/neofs-api-go/v2/refs/grpc"
 	"github.com/nspcc-dev/neofs-api-go/v2/session"
 	sessionGRPC "github.com/nspcc-dev/neofs-api-go/v2/session/grpc"
-	"github.com/pkg/errors"
 )
 
 func TypeToGRPCField(t Type) object.ObjectType {
@@ -802,7 +801,7 @@ func (r *GetResponseBody) FromGRPCMessage(m grpc.Message) error {
 			err = partSplit.FromGRPCMessage(pt.SplitInfo)
 		}
 	default:
-		err = errors.Errorf("unknown get object part %T", pt)
+		err = fmt.Errorf("unknown get object part %T", pt)
 	}
 
 	return err
@@ -985,7 +984,7 @@ func (r *PutRequestBody) FromGRPCMessage(m grpc.Message) error {
 			err = partChunk.FromGRPCMessage(pt)
 		}
 	default:
-		err = errors.Errorf("unknown put object part %T", pt)
+		err = fmt.Errorf("unknown put object part %T", pt)
 	}
 
 	return err
@@ -1379,7 +1378,7 @@ func (r *HeadResponseBody) FromGRPCMessage(m grpc.Message) error {
 			err = partSplit.FromGRPCMessage(pt.SplitInfo)
 		}
 	default:
-		err = errors.Errorf("unknown head part %T", pt)
+		err = fmt.Errorf("unknown head part %T", pt)
 	}
 
 	return err
@@ -1854,7 +1853,7 @@ func (r *GetRangeResponseBody) FromGRPCMessage(m grpc.Message) error {
 			err = partSplit.FromGRPCMessage(pt)
 		}
 	default:
-		err = errors.Errorf("unknown get range part %T", pt)
+		err = fmt.Errorf("unknown get range part %T", pt)
 	}
 
 	return err

--- a/v2/object/grpc/client.go
+++ b/v2/object/grpc/client.go
@@ -2,8 +2,8 @@ package object
 
 import (
 	"context"
+	"errors"
 
-	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 )
 

--- a/v2/session/convert.go
+++ b/v2/session/convert.go
@@ -10,7 +10,6 @@ import (
 	"github.com/nspcc-dev/neofs-api-go/v2/refs"
 	refsGRPC "github.com/nspcc-dev/neofs-api-go/v2/refs/grpc"
 	session "github.com/nspcc-dev/neofs-api-go/v2/session/grpc"
-	"github.com/pkg/errors"
 )
 
 func (c *CreateRequestBody) ToGRPCMessage() grpc.Message {
@@ -731,7 +730,7 @@ func (t *SessionTokenBody) FromGRPCMessage(m grpc.Message) error {
 
 	switch val := v.GetContext().(type) {
 	default:
-		err = errors.Errorf("unknown session context %T", val)
+		err = fmt.Errorf("unknown session context %T", val)
 	case nil:
 	case *session.SessionToken_Body_Object:
 		ctx, ok := t.ctx.(*ObjectSessionContext)

--- a/v2/session/grpc/client.go
+++ b/v2/session/grpc/client.go
@@ -2,8 +2,8 @@ package session
 
 import (
 	"context"
+	"errors"
 
-	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 )
 


### PR DESCRIPTION
Use stdlib `errors` instead.

Signed-off-by: Evgenii Stratonikov <evgeniy@nspcc.ru>