### PR TITLE
Feature/add TLS options to client

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -35,7 +35,6 @@ func New(opts ...Option) (Client, error) {
 	}
 
 	return &clientImpl{
-		raw:  client.New(),
 		opts: clientOptions,
 	}, nil
 }

--- a/pkg/client/opts.go
+++ b/pkg/client/opts.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"crypto/ecdsa"
+	"crypto/tls"
 	"time"
 
 	"github.com/nspcc-dev/neofs-api-go/pkg"
@@ -110,7 +111,7 @@ func v2MetaHeaderFromOpts(options *callOptions) *v2session.RequestMetaHeader {
 
 func defaultClientOptions() *clientOptions {
 	return &clientOptions{
-		rawOpts: make([]client.Option, 0, 3),
+		rawOpts: make([]client.Option, 0, 4),
 	}
 }
 
@@ -130,6 +131,13 @@ func WithGRPCConnection(grpcConn *grpc.ClientConn) Option {
 func WithDialTimeout(dur time.Duration) Option {
 	return func(opts *clientOptions) {
 		opts.rawOpts = append(opts.rawOpts, client.WithDialTimeout(dur))
+	}
+}
+
+// WithTLSConfig returns option to set connection's TLS config to the remote node.
+func WithTLSConfig(cfg *tls.Config) Option {
+	return func(opts *clientOptions) {
+		opts.rawOpts = append(opts.rawOpts, client.WithTLSCfg(cfg))
 	}
 }
 

--- a/rpc/client/connect.go
+++ b/rpc/client/connect.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/nspcc-dev/neofs-api-go/rpc/grpc"
 	grpcstd "google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 )
 
 func (c *Client) createGRPCClient() (err error) {
@@ -33,8 +34,17 @@ func (c *Client) openGRPCConn() error {
 
 	var err error
 
+	var credOpt grpcstd.DialOption
+
+	if c.tlsCfg != nil {
+		creds := credentials.NewTLS(c.tlsCfg)
+		credOpt = grpcstd.WithTransportCredentials(creds)
+	} else {
+		credOpt = grpcstd.WithInsecure()
+	}
+
 	dialCtx, cancel := context.WithTimeout(context.Background(), c.dialTimeout)
-	c.conn, err = grpcstd.DialContext(dialCtx, c.addr, grpcstd.WithInsecure())
+	c.conn, err = grpcstd.DialContext(dialCtx, c.addr, credOpt)
 	cancel()
 
 	return err

--- a/rpc/client/options.go
+++ b/rpc/client/options.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"crypto/tls"
 	"time"
 
 	"google.golang.org/grpc"
@@ -13,6 +14,8 @@ type cfg struct {
 	addr string
 
 	dialTimeout time.Duration
+
+	tlsCfg *tls.Config
 
 	conn *grpc.ClientConn
 }
@@ -45,6 +48,18 @@ func WithDialTimeout(v time.Duration) Option {
 	return func(c *cfg) {
 		if v > 0 {
 			c.dialTimeout = v
+		}
+	}
+}
+
+// WithTLSCfg returns option to specify
+// TLS configuration.
+//
+// Ignored if WithGRPCConn is provided.
+func WithTLSCfg(v *tls.Config) Option {
+	return func(c *cfg) {
+		if v != nil {
+			c.tlsCfg = v
 		}
 	}
 }


### PR DESCRIPTION
Relates to https://github.com/nspcc-dev/neofs-node/issues/455.

TLS configuration option was added to the client.
Deleted useless raw client initialization in `clientImpl`'s constructor.