### PR TITLE
Connection readers on clients

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"io"
 	"sync"
 
 	"github.com/nspcc-dev/neofs-api-go/rpc/client"
@@ -17,6 +18,12 @@ type Client interface {
 
 	// Raw must return underlying raw protobuf client.
 	Raw() *client.Client
+
+	// Conn must return underlying connection.
+	//
+	// Must return a non-nil result after the first RPC call
+	// completed without a connection error.
+	Conn() io.Closer
 }
 
 type clientImpl struct {

--- a/pkg/client/raw.go
+++ b/pkg/client/raw.go
@@ -1,6 +1,8 @@
 package client
 
 import (
+	"io"
+
 	"github.com/nspcc-dev/neofs-api-go/rpc/client"
 )
 
@@ -11,4 +13,9 @@ func (c *clientImpl) Raw() *client.Client {
 	})
 
 	return c.raw
+}
+
+// implements Client.Conn method.
+func (c *clientImpl) Conn() io.Closer {
+	return c.raw.Conn()
 }

--- a/rpc/client/conn.go
+++ b/rpc/client/conn.go
@@ -1,0 +1,22 @@
+package client
+
+import (
+	"io"
+)
+
+// Conn returns underlying connection.
+//
+// Returns non-nil result after the first Init() call
+// completed without a connection error.
+//
+// Conn is NPE-safe: returns nil if Client is nil.
+//
+// Client should not be used after Close() call
+// on the connection: behavior is undefined.
+func (c *Client) Conn() io.Closer {
+	if c != nil {
+		return c.gRPCClient.Conn()
+	}
+
+	return nil
+}

--- a/rpc/grpc/conn.go
+++ b/rpc/grpc/conn.go
@@ -1,0 +1,19 @@
+package grpc
+
+import (
+	"io"
+)
+
+// Conn returns underlying connection.
+//
+// Conn is NPE-safe: returns nil if Client is nil.
+//
+// Client should not be used after Close() call
+// on the connection: behavior is undefined.
+func (c *Client) Conn() io.Closer {
+	if c != nil {
+		return c.con
+	}
+
+	return nil
+}


### PR DESCRIPTION
Closes #196.

Minimum necessary connection control - closing (so `io.Closer`). For more flexible control of a particular type of connection, casters will be implemented in the future according to needs.