### PR TITLE
Fix/Do not allocate memory if `empty`

### DIFF
--- a/v2/accounting/test/generate.go
+++ b/v2/accounting/test/generate.go
@@ -9,7 +9,10 @@ import (
 func GenerateBalanceRequest(empty bool) *accounting.BalanceRequest {
 	m := new(accounting.BalanceRequest)
 
-	m.SetBody(GenerateBalanceRequestBody(empty))
+	if !empty {
+		m.SetBody(GenerateBalanceRequestBody(false))
+	}
+
 	m.SetMetaHeader(sessiontest.GenerateRequestMetaHeader(empty))
 	m.SetVerificationHeader(sessiontest.GenerateRequestVerificationHeader(empty))
 
@@ -19,7 +22,9 @@ func GenerateBalanceRequest(empty bool) *accounting.BalanceRequest {
 func GenerateBalanceRequestBody(empty bool) *accounting.BalanceRequestBody {
 	m := new(accounting.BalanceRequestBody)
 
-	m.SetOwnerID(accountingtest.GenerateOwnerID(empty))
+	if !empty {
+		m.SetOwnerID(accountingtest.GenerateOwnerID(false))
+	}
 
 	return m
 }
@@ -27,7 +32,10 @@ func GenerateBalanceRequestBody(empty bool) *accounting.BalanceRequestBody {
 func GenerateBalanceResponse(empty bool) *accounting.BalanceResponse {
 	m := new(accounting.BalanceResponse)
 
-	m.SetBody(GenerateBalanceResponseBody(empty))
+	if !empty {
+		m.SetBody(GenerateBalanceResponseBody(false))
+	}
+
 	m.SetMetaHeader(sessiontest.GenerateResponseMetaHeader(empty))
 	m.SetVerificationHeader(sessiontest.GenerateResponseVerificationHeader(empty))
 
@@ -37,7 +45,9 @@ func GenerateBalanceResponse(empty bool) *accounting.BalanceResponse {
 func GenerateBalanceResponseBody(empty bool) *accounting.BalanceResponseBody {
 	m := new(accounting.BalanceResponseBody)
 
-	m.SetBalance(GenerateDecimal(empty))
+	if !empty {
+		m.SetBalance(GenerateDecimal(false))
+	}
 
 	return m
 }

--- a/v2/acl/test/generate.go
+++ b/v2/acl/test/generate.go
@@ -8,7 +8,10 @@ import (
 func GenerateBearerToken(empty bool) *acl.BearerToken {
 	m := new(acl.BearerToken)
 
-	m.SetBody(GenerateBearerTokenBody(empty))
+	if !empty {
+		m.SetBody(GenerateBearerTokenBody(false))
+	}
+
 	m.SetSignature(accountingtest.GenerateSignature(empty))
 
 	return m
@@ -17,9 +20,11 @@ func GenerateBearerToken(empty bool) *acl.BearerToken {
 func GenerateBearerTokenBody(empty bool) *acl.BearerTokenBody {
 	m := new(acl.BearerTokenBody)
 
-	m.SetOwnerID(accountingtest.GenerateOwnerID(empty))
-	m.SetEACL(GenerateTable(empty))
-	m.SetLifetime(GenerateTokenLifetime(empty))
+	if !empty {
+		m.SetOwnerID(accountingtest.GenerateOwnerID(false))
+		m.SetEACL(GenerateTable(false))
+		m.SetLifetime(GenerateTokenLifetime(false))
+	}
 
 	return m
 }
@@ -27,15 +32,18 @@ func GenerateBearerTokenBody(empty bool) *acl.BearerTokenBody {
 func GenerateTable(empty bool) *acl.Table {
 	m := new(acl.Table)
 
-	m.SetRecords(GenerateRecords(empty))
-	m.SetContainerID(accountingtest.GenerateContainerID(empty))
+	if !empty {
+		m.SetRecords(GenerateRecords(false))
+		m.SetContainerID(accountingtest.GenerateContainerID(false))
+	}
+
 	m.SetVersion(accountingtest.GenerateVersion(empty))
 
 	return m
 }
 
 func GenerateRecords(empty bool) []*acl.Record {
-	rs := make([]*acl.Record, 0)
+	var rs []*acl.Record
 
 	if !empty {
 		rs = append(rs,
@@ -53,16 +61,15 @@ func GenerateRecord(empty bool) *acl.Record {
 	if !empty {
 		m.SetAction(acl.ActionAllow)
 		m.SetOperation(acl.OperationGet)
+		m.SetFilters(GenerateFilters(false))
+		m.SetTargets(GenerateTargets(false))
 	}
-
-	m.SetFilters(GenerateFilters(empty))
-	m.SetTargets(GenerateTargets(empty))
 
 	return m
 }
 
 func GenerateFilters(empty bool) []*acl.HeaderFilter {
-	fs := make([]*acl.HeaderFilter, 0)
+	var fs []*acl.HeaderFilter
 
 	if !empty {
 		fs = append(fs,
@@ -88,7 +95,7 @@ func GenerateFilter(empty bool) *acl.HeaderFilter {
 }
 
 func GenerateTargets(empty bool) []*acl.Target {
-	ts := make([]*acl.Target, 0)
+	var ts []*acl.Target
 
 	if !empty {
 		ts = append(ts,

--- a/v2/audit/test/generate.go
+++ b/v2/audit/test/generate.go
@@ -19,12 +19,11 @@ func GenerateDataAuditResult(empty bool) *audit.DataAuditResult {
 		m.SetFailNodes([][]byte{{3}, {4}})
 		m.SetRequests(666)
 		m.SetRetries(777)
+		m.SetVersion(refstest.GenerateVersion(false))
+		m.SetContainerID(refstest.GenerateContainerID(false))
+		m.SetPassSG(refstest.GenerateObjectIDs(false))
+		m.SetFailSG(refstest.GenerateObjectIDs(false))
 	}
-
-	m.SetVersion(refstest.GenerateVersion(empty))
-	m.SetContainerID(refstest.GenerateContainerID(empty))
-	m.SetPassSG(refstest.GenerateObjectIDs(empty))
-	m.SetFailSG(refstest.GenerateObjectIDs(empty))
 
 	return m
 }

--- a/v2/container/test/generate.go
+++ b/v2/container/test/generate.go
@@ -19,7 +19,9 @@ func GenerateAttribute(empty bool) *container.Attribute {
 	return m
 }
 
-func GenerateAttributes(empty bool) (res []*container.Attribute) {
+func GenerateAttributes(empty bool) []*container.Attribute {
+	var res []*container.Attribute
+
 	if !empty {
 		res = append(res,
 			GenerateAttribute(false),
@@ -27,7 +29,7 @@ func GenerateAttributes(empty bool) (res []*container.Attribute) {
 		)
 	}
 
-	return
+	return res
 }
 
 func GenerateContainer(empty bool) *container.Container {
@@ -36,12 +38,12 @@ func GenerateContainer(empty bool) *container.Container {
 	if !empty {
 		m.SetBasicACL(12)
 		m.SetNonce([]byte{1, 2, 3})
+		m.SetOwnerID(refstest.GenerateOwnerID(false))
+		m.SetAttributes(GenerateAttributes(false))
+		m.SetPlacementPolicy(netmaptest.GeneratePlacementPolicy(false))
 	}
 
-	m.SetOwnerID(refstest.GenerateOwnerID(empty))
 	m.SetVersion(refstest.GenerateVersion(empty))
-	m.SetAttributes(GenerateAttributes(empty))
-	m.SetPlacementPolicy(netmaptest.GeneratePlacementPolicy(empty))
 
 	return m
 }
@@ -49,7 +51,10 @@ func GenerateContainer(empty bool) *container.Container {
 func GeneratePutRequestBody(empty bool) *container.PutRequestBody {
 	m := new(container.PutRequestBody)
 
-	m.SetContainer(GenerateContainer(empty))
+	if !empty {
+		m.SetContainer(GenerateContainer(false))
+	}
+
 	m.SetSignature(refstest.GenerateSignature(empty))
 
 	return m
@@ -58,7 +63,10 @@ func GeneratePutRequestBody(empty bool) *container.PutRequestBody {
 func GeneratePutRequest(empty bool) *container.PutRequest {
 	m := new(container.PutRequest)
 
-	m.SetBody(GeneratePutRequestBody(empty))
+	if !empty {
+		m.SetBody(GeneratePutRequestBody(false))
+	}
+
 	m.SetMetaHeader(sessiontest.GenerateRequestMetaHeader(empty))
 	m.SetVerificationHeader(sessiontest.GenerateRequestVerificationHeader(empty))
 
@@ -68,7 +76,9 @@ func GeneratePutRequest(empty bool) *container.PutRequest {
 func GeneratePutResponseBody(empty bool) *container.PutResponseBody {
 	m := new(container.PutResponseBody)
 
-	m.SetContainerID(refstest.GenerateContainerID(empty))
+	if !empty {
+		m.SetContainerID(refstest.GenerateContainerID(false))
+	}
 
 	return m
 }
@@ -76,7 +86,10 @@ func GeneratePutResponseBody(empty bool) *container.PutResponseBody {
 func GeneratePutResponse(empty bool) *container.PutResponse {
 	m := new(container.PutResponse)
 
-	m.SetBody(GeneratePutResponseBody(empty))
+	if !empty {
+		m.SetBody(GeneratePutResponseBody(false))
+	}
+
 	m.SetMetaHeader(sessiontest.GenerateResponseMetaHeader(empty))
 	m.SetVerificationHeader(sessiontest.GenerateResponseVerificationHeader(empty))
 
@@ -86,7 +99,9 @@ func GeneratePutResponse(empty bool) *container.PutResponse {
 func GenerateGetRequestBody(empty bool) *container.GetRequestBody {
 	m := new(container.GetRequestBody)
 
-	m.SetContainerID(refstest.GenerateContainerID(empty))
+	if !empty {
+		m.SetContainerID(refstest.GenerateContainerID(false))
+	}
 
 	return m
 }
@@ -94,7 +109,10 @@ func GenerateGetRequestBody(empty bool) *container.GetRequestBody {
 func GenerateGetRequest(empty bool) *container.GetRequest {
 	m := new(container.GetRequest)
 
-	m.SetBody(GenerateGetRequestBody(empty))
+	if !empty {
+		m.SetBody(GenerateGetRequestBody(false))
+	}
+
 	m.SetMetaHeader(sessiontest.GenerateRequestMetaHeader(empty))
 	m.SetVerificationHeader(sessiontest.GenerateRequestVerificationHeader(empty))
 
@@ -104,7 +122,10 @@ func GenerateGetRequest(empty bool) *container.GetRequest {
 func GenerateGetResponseBody(empty bool) *container.GetResponseBody {
 	m := new(container.GetResponseBody)
 
-	m.SetContainer(GenerateContainer(empty))
+	if !empty {
+		m.SetContainer(GenerateContainer(false))
+	}
+
 	m.SetSignature(refstest.GenerateSignature(empty))
 	m.SetSessionToken(sessiontest.GenerateSessionToken(empty))
 
@@ -114,7 +135,10 @@ func GenerateGetResponseBody(empty bool) *container.GetResponseBody {
 func GenerateGetResponse(empty bool) *container.GetResponse {
 	m := new(container.GetResponse)
 
-	m.SetBody(GenerateGetResponseBody(empty))
+	if !empty {
+		m.SetBody(GenerateGetResponseBody(false))
+	}
+
 	m.SetMetaHeader(sessiontest.GenerateResponseMetaHeader(empty))
 	m.SetVerificationHeader(sessiontest.GenerateResponseVerificationHeader(empty))
 
@@ -124,7 +148,10 @@ func GenerateGetResponse(empty bool) *container.GetResponse {
 func GenerateDeleteRequestBody(empty bool) *container.DeleteRequestBody {
 	m := new(container.DeleteRequestBody)
 
-	m.SetContainerID(refstest.GenerateContainerID(empty))
+	if !empty {
+		m.SetContainerID(refstest.GenerateContainerID(false))
+	}
+
 	m.SetSignature(refstest.GenerateSignature(empty))
 
 	return m
@@ -133,7 +160,10 @@ func GenerateDeleteRequestBody(empty bool) *container.DeleteRequestBody {
 func GenerateDeleteRequest(empty bool) *container.DeleteRequest {
 	m := new(container.DeleteRequest)
 
-	m.SetBody(GenerateDeleteRequestBody(empty))
+	if !empty {
+		m.SetBody(GenerateDeleteRequestBody(false))
+	}
+
 	m.SetMetaHeader(sessiontest.GenerateRequestMetaHeader(empty))
 	m.SetVerificationHeader(sessiontest.GenerateRequestVerificationHeader(empty))
 
@@ -149,7 +179,10 @@ func GenerateDeleteResponseBody(empty bool) *container.DeleteResponseBody {
 func GenerateDeleteResponse(empty bool) *container.DeleteResponse {
 	m := new(container.DeleteResponse)
 
-	m.SetBody(GenerateDeleteResponseBody(empty))
+	if !empty {
+		m.SetBody(GenerateDeleteResponseBody(false))
+	}
+
 	m.SetMetaHeader(sessiontest.GenerateResponseMetaHeader(empty))
 	m.SetVerificationHeader(sessiontest.GenerateResponseVerificationHeader(empty))
 
@@ -159,7 +192,9 @@ func GenerateDeleteResponse(empty bool) *container.DeleteResponse {
 func GenerateListRequestBody(empty bool) *container.ListRequestBody {
 	m := new(container.ListRequestBody)
 
-	m.SetOwnerID(refstest.GenerateOwnerID(empty))
+	if !empty {
+		m.SetOwnerID(refstest.GenerateOwnerID(false))
+	}
 
 	return m
 }
@@ -167,7 +202,10 @@ func GenerateListRequestBody(empty bool) *container.ListRequestBody {
 func GenerateListRequest(empty bool) *container.ListRequest {
 	m := new(container.ListRequest)
 
-	m.SetBody(GenerateListRequestBody(empty))
+	if !empty {
+		m.SetBody(GenerateListRequestBody(false))
+	}
+
 	m.SetMetaHeader(sessiontest.GenerateRequestMetaHeader(empty))
 	m.SetVerificationHeader(sessiontest.GenerateRequestVerificationHeader(empty))
 
@@ -177,7 +215,9 @@ func GenerateListRequest(empty bool) *container.ListRequest {
 func GenerateListResponseBody(empty bool) *container.ListResponseBody {
 	m := new(container.ListResponseBody)
 
-	m.SetContainerIDs(refstest.GenerateContainerIDs(empty))
+	if !empty {
+		m.SetContainerIDs(refstest.GenerateContainerIDs(false))
+	}
 
 	return m
 }
@@ -185,7 +225,10 @@ func GenerateListResponseBody(empty bool) *container.ListResponseBody {
 func GenerateListResponse(empty bool) *container.ListResponse {
 	m := new(container.ListResponse)
 
-	m.SetBody(GenerateListResponseBody(empty))
+	if !empty {
+		m.SetBody(GenerateListResponseBody(false))
+	}
+
 	m.SetMetaHeader(sessiontest.GenerateResponseMetaHeader(empty))
 	m.SetVerificationHeader(sessiontest.GenerateResponseVerificationHeader(empty))
 
@@ -195,7 +238,10 @@ func GenerateListResponse(empty bool) *container.ListResponse {
 func GenerateSetExtendedACLRequestBody(empty bool) *container.SetExtendedACLRequestBody {
 	m := new(container.SetExtendedACLRequestBody)
 
-	m.SetEACL(acltest.GenerateTable(empty))
+	if !empty {
+		m.SetEACL(acltest.GenerateTable(false))
+	}
+
 	m.SetSignature(refstest.GenerateSignature(empty))
 
 	return m
@@ -204,7 +250,10 @@ func GenerateSetExtendedACLRequestBody(empty bool) *container.SetExtendedACLRequ
 func GenerateSetExtendedACLRequest(empty bool) *container.SetExtendedACLRequest {
 	m := new(container.SetExtendedACLRequest)
 
-	m.SetBody(GenerateSetExtendedACLRequestBody(empty))
+	if !empty {
+		m.SetBody(GenerateSetExtendedACLRequestBody(false))
+	}
+
 	m.SetMetaHeader(sessiontest.GenerateRequestMetaHeader(empty))
 	m.SetVerificationHeader(sessiontest.GenerateRequestVerificationHeader(empty))
 
@@ -220,7 +269,10 @@ func GenerateSetExtendedACLResponseBody(empty bool) *container.SetExtendedACLRes
 func GenerateSetExtendedACLResponse(empty bool) *container.SetExtendedACLResponse {
 	m := new(container.SetExtendedACLResponse)
 
-	m.SetBody(GenerateSetExtendedACLResponseBody(empty))
+	if !empty {
+		m.SetBody(GenerateSetExtendedACLResponseBody(false))
+	}
+
 	m.SetMetaHeader(sessiontest.GenerateResponseMetaHeader(empty))
 	m.SetVerificationHeader(sessiontest.GenerateResponseVerificationHeader(empty))
 
@@ -230,7 +282,9 @@ func GenerateSetExtendedACLResponse(empty bool) *container.SetExtendedACLRespons
 func GenerateGetExtendedACLRequestBody(empty bool) *container.GetExtendedACLRequestBody {
 	m := new(container.GetExtendedACLRequestBody)
 
-	m.SetContainerID(refstest.GenerateContainerID(empty))
+	if !empty {
+		m.SetContainerID(refstest.GenerateContainerID(false))
+	}
 
 	return m
 }
@@ -238,7 +292,10 @@ func GenerateGetExtendedACLRequestBody(empty bool) *container.GetExtendedACLRequ
 func GenerateGetExtendedACLRequest(empty bool) *container.GetExtendedACLRequest {
 	m := new(container.GetExtendedACLRequest)
 
-	m.SetBody(GenerateGetExtendedACLRequestBody(empty))
+	if !empty {
+		m.SetBody(GenerateGetExtendedACLRequestBody(false))
+	}
+
 	m.SetMetaHeader(sessiontest.GenerateRequestMetaHeader(empty))
 	m.SetVerificationHeader(sessiontest.GenerateRequestVerificationHeader(empty))
 
@@ -248,7 +305,10 @@ func GenerateGetExtendedACLRequest(empty bool) *container.GetExtendedACLRequest 
 func GenerateGetExtendedACLResponseBody(empty bool) *container.GetExtendedACLResponseBody {
 	m := new(container.GetExtendedACLResponseBody)
 
-	m.SetEACL(acltest.GenerateTable(empty))
+	if !empty {
+		m.SetEACL(acltest.GenerateTable(false))
+	}
+
 	m.SetSignature(refstest.GenerateSignature(empty))
 	m.SetSessionToken(sessiontest.GenerateSessionToken(empty))
 
@@ -258,7 +318,10 @@ func GenerateGetExtendedACLResponseBody(empty bool) *container.GetExtendedACLRes
 func GenerateGetExtendedACLResponse(empty bool) *container.GetExtendedACLResponse {
 	m := new(container.GetExtendedACLResponse)
 
-	m.SetBody(GenerateGetExtendedACLResponseBody(empty))
+	if !empty {
+		m.SetBody(GenerateGetExtendedACLResponseBody(false))
+	}
+
 	m.SetMetaHeader(sessiontest.GenerateResponseMetaHeader(empty))
 	m.SetVerificationHeader(sessiontest.GenerateResponseVerificationHeader(empty))
 
@@ -268,14 +331,18 @@ func GenerateGetExtendedACLResponse(empty bool) *container.GetExtendedACLRespons
 func GenerateUsedSpaceAnnouncement(empty bool) *container.UsedSpaceAnnouncement {
 	m := new(container.UsedSpaceAnnouncement)
 
-	m.SetContainerID(refstest.GenerateContainerID(empty))
-	m.SetEpoch(1)
-	m.SetUsedSpace(2)
+	if !empty {
+		m.SetContainerID(refstest.GenerateContainerID(false))
+		m.SetEpoch(1)
+		m.SetUsedSpace(2)
+	}
 
 	return m
 }
 
-func GenerateUsedSpaceAnnouncements(empty bool) (res []*container.UsedSpaceAnnouncement) {
+func GenerateUsedSpaceAnnouncements(empty bool) []*container.UsedSpaceAnnouncement {
+	var res []*container.UsedSpaceAnnouncement
+
 	if !empty {
 		res = append(res,
 			GenerateUsedSpaceAnnouncement(false),
@@ -283,13 +350,15 @@ func GenerateUsedSpaceAnnouncements(empty bool) (res []*container.UsedSpaceAnnou
 		)
 	}
 
-	return
+	return res
 }
 
 func GenerateAnnounceUsedSpaceRequestBody(empty bool) *container.AnnounceUsedSpaceRequestBody {
 	m := new(container.AnnounceUsedSpaceRequestBody)
 
-	m.SetAnnouncements(GenerateUsedSpaceAnnouncements(empty))
+	if !empty {
+		m.SetAnnouncements(GenerateUsedSpaceAnnouncements(false))
+	}
 
 	return m
 }
@@ -297,7 +366,10 @@ func GenerateAnnounceUsedSpaceRequestBody(empty bool) *container.AnnounceUsedSpa
 func GenerateAnnounceUsedSpaceRequest(empty bool) *container.AnnounceUsedSpaceRequest {
 	m := new(container.AnnounceUsedSpaceRequest)
 
-	m.SetBody(GenerateAnnounceUsedSpaceRequestBody(empty))
+	if !empty {
+		m.SetBody(GenerateAnnounceUsedSpaceRequestBody(false))
+	}
+
 	m.SetMetaHeader(sessiontest.GenerateRequestMetaHeader(empty))
 	m.SetVerificationHeader(sessiontest.GenerateRequestVerificationHeader(empty))
 
@@ -313,7 +385,10 @@ func GenerateAnnounceUsedSpaceResponseBody(empty bool) *container.AnnounceUsedSp
 func GenerateAnnounceUsedSpaceResponse(empty bool) *container.AnnounceUsedSpaceResponse {
 	m := new(container.AnnounceUsedSpaceResponse)
 
-	m.SetBody(GenerateAnnounceUsedSpaceResponseBody(empty))
+	if !empty {
+		m.SetBody(GenerateAnnounceUsedSpaceResponseBody(false))
+	}
+
 	m.SetMetaHeader(sessiontest.GenerateResponseMetaHeader(empty))
 	m.SetVerificationHeader(sessiontest.GenerateResponseVerificationHeader(empty))
 

--- a/v2/netmap/test/generate.go
+++ b/v2/netmap/test/generate.go
@@ -30,7 +30,9 @@ func generateFilter(empty, withSub bool) *netmap.Filter {
 	return m
 }
 
-func GenerateFilters(empty bool) (res []*netmap.Filter) {
+func GenerateFilters(empty bool) []*netmap.Filter {
+	var res []*netmap.Filter
+
 	if !empty {
 		res = append(res,
 			GenerateFilter(false),
@@ -38,7 +40,7 @@ func GenerateFilters(empty bool) (res []*netmap.Filter) {
 		)
 	}
 
-	return
+	return res
 }
 
 func GenerateSelector(empty bool) *netmap.Selector {
@@ -55,7 +57,9 @@ func GenerateSelector(empty bool) *netmap.Selector {
 	return m
 }
 
-func GenerateSelectors(empty bool) (res []*netmap.Selector) {
+func GenerateSelectors(empty bool) []*netmap.Selector {
+	var res []*netmap.Selector
+
 	if !empty {
 		res = append(res,
 			GenerateSelector(false),
@@ -63,7 +67,7 @@ func GenerateSelectors(empty bool) (res []*netmap.Selector) {
 		)
 	}
 
-	return
+	return res
 }
 
 func GenerateReplica(empty bool) *netmap.Replica {
@@ -77,7 +81,9 @@ func GenerateReplica(empty bool) *netmap.Replica {
 	return m
 }
 
-func GenerateReplicas(empty bool) (res []*netmap.Replica) {
+func GenerateReplicas(empty bool) []*netmap.Replica {
+	var res []*netmap.Replica
+
 	if !empty {
 		res = append(res,
 			GenerateReplica(false),
@@ -85,7 +91,7 @@ func GenerateReplicas(empty bool) (res []*netmap.Replica) {
 		)
 	}
 
-	return
+	return res
 }
 
 func GeneratePlacementPolicy(empty bool) *netmap.PlacementPolicy {
@@ -93,11 +99,10 @@ func GeneratePlacementPolicy(empty bool) *netmap.PlacementPolicy {
 
 	if !empty {
 		m.SetContainerBackupFactor(322)
+		m.SetFilters(GenerateFilters(false))
+		m.SetSelectors(GenerateSelectors(false))
+		m.SetReplicas(GenerateReplicas(false))
 	}
-
-	m.SetFilters(GenerateFilters(empty))
-	m.SetSelectors(GenerateSelectors(empty))
-	m.SetReplicas(GenerateReplicas(empty))
 
 	return m
 }
@@ -113,7 +118,9 @@ func GenerateAttribute(empty bool) *netmap.Attribute {
 	return m
 }
 
-func GenerateAttributes(empty bool) (res []*netmap.Attribute) {
+func GenerateAttributes(empty bool) []*netmap.Attribute {
+	var res []*netmap.Attribute
+
 	if !empty {
 		res = append(res,
 			GenerateAttribute(false),
@@ -121,7 +128,7 @@ func GenerateAttributes(empty bool) (res []*netmap.Attribute) {
 		)
 	}
 
-	return
+	return res
 }
 
 func GenerateNodeInfo(empty bool) *netmap.NodeInfo {
@@ -131,9 +138,8 @@ func GenerateNodeInfo(empty bool) *netmap.NodeInfo {
 		m.SetAddress("node address")
 		m.SetPublicKey([]byte{1, 2, 3})
 		m.SetState(33)
+		m.SetAttributes(GenerateAttributes(empty))
 	}
-
-	m.SetAttributes(GenerateAttributes(empty))
 
 	return m
 }
@@ -147,7 +153,10 @@ func GenerateLocalNodeInfoRequestBody(empty bool) *netmap.LocalNodeInfoRequestBo
 func GenerateLocalNodeInfoRequest(empty bool) *netmap.LocalNodeInfoRequest {
 	m := new(netmap.LocalNodeInfoRequest)
 
-	m.SetBody(GenerateLocalNodeInfoRequestBody(empty))
+	if !empty {
+		m.SetBody(GenerateLocalNodeInfoRequestBody(false))
+	}
+
 	m.SetMetaHeader(sessiontest.GenerateRequestMetaHeader(empty))
 	m.SetVerificationHeader(sessiontest.GenerateRequestVerificationHeader(empty))
 
@@ -157,8 +166,11 @@ func GenerateLocalNodeInfoRequest(empty bool) *netmap.LocalNodeInfoRequest {
 func GenerateLocalNodeInfoResponseBody(empty bool) *netmap.LocalNodeInfoResponseBody {
 	m := new(netmap.LocalNodeInfoResponseBody)
 
+	if !empty {
+		m.SetNodeInfo(GenerateNodeInfo(false))
+	}
+
 	m.SetVersion(refstest.GenerateVersion(empty))
-	m.SetNodeInfo(GenerateNodeInfo(empty))
 
 	return m
 }
@@ -166,7 +178,10 @@ func GenerateLocalNodeInfoResponseBody(empty bool) *netmap.LocalNodeInfoResponse
 func GenerateLocalNodeInfoResponse(empty bool) *netmap.LocalNodeInfoResponse {
 	m := new(netmap.LocalNodeInfoResponse)
 
-	m.SetBody(GenerateLocalNodeInfoResponseBody(empty))
+	if !empty {
+		m.SetBody(GenerateLocalNodeInfoResponseBody(false))
+	}
+
 	m.SetMetaHeader(sessiontest.GenerateResponseMetaHeader(empty))
 	m.SetVerificationHeader(sessiontest.GenerateResponseVerificationHeader(empty))
 
@@ -193,7 +208,10 @@ func GenerateNetworkInfoRequestBody(empty bool) *netmap.NetworkInfoRequestBody {
 func GenerateNetworkInfoRequest(empty bool) *netmap.NetworkInfoRequest {
 	m := new(netmap.NetworkInfoRequest)
 
-	m.SetBody(GenerateNetworkInfoRequestBody(empty))
+	if !empty {
+		m.SetBody(GenerateNetworkInfoRequestBody(false))
+	}
+
 	m.SetMetaHeader(sessiontest.GenerateRequestMetaHeader(empty))
 	m.SetVerificationHeader(sessiontest.GenerateRequestVerificationHeader(empty))
 
@@ -203,7 +221,9 @@ func GenerateNetworkInfoRequest(empty bool) *netmap.NetworkInfoRequest {
 func GenerateNetworkInfoResponseBody(empty bool) *netmap.NetworkInfoResponseBody {
 	m := new(netmap.NetworkInfoResponseBody)
 
-	m.SetNetworkInfo(GenerateNetworkInfo(empty))
+	if !empty {
+		m.SetNetworkInfo(GenerateNetworkInfo(false))
+	}
 
 	return m
 }
@@ -211,7 +231,10 @@ func GenerateNetworkInfoResponseBody(empty bool) *netmap.NetworkInfoResponseBody
 func GenerateNetworkInfoResponse(empty bool) *netmap.NetworkInfoResponse {
 	m := new(netmap.NetworkInfoResponse)
 
-	m.SetBody(GenerateNetworkInfoResponseBody(empty))
+	if !empty {
+		m.SetBody(GenerateNetworkInfoResponseBody(false))
+	}
+
 	m.SetMetaHeader(sessiontest.GenerateResponseMetaHeader(empty))
 	m.SetVerificationHeader(sessiontest.GenerateResponseVerificationHeader(empty))
 

--- a/v2/object/test/generate.go
+++ b/v2/object/test/generate.go
@@ -13,10 +13,10 @@ func GenerateShortHeader(empty bool) *object.ShortHeader {
 		m.SetObjectType(13)
 		m.SetCreationEpoch(100)
 		m.SetPayloadLength(12321)
+		m.SetOwnerID(refstest.GenerateOwnerID(false))
 	}
 
 	m.SetVersion(refstest.GenerateVersion(empty))
-	m.SetOwnerID(refstest.GenerateOwnerID(empty))
 	m.SetHomomorphicHash(refstest.GenerateChecksum(empty))
 	m.SetPayloadHash(refstest.GenerateChecksum(empty))
 
@@ -34,7 +34,9 @@ func GenerateAttribute(empty bool) *object.Attribute {
 	return m
 }
 
-func GenerateAttributes(empty bool) (res []*object.Attribute) {
+func GenerateAttributes(empty bool) []*object.Attribute {
+	var res []*object.Attribute
+
 	if !empty {
 		res = append(res,
 			GenerateAttribute(false),
@@ -42,7 +44,7 @@ func GenerateAttributes(empty bool) (res []*object.Attribute) {
 		)
 	}
 
-	return
+	return res
 }
 
 func GenerateSplitHeader(empty bool) *object.SplitHeader {
@@ -54,12 +56,12 @@ func generateSplitHeader(empty, withPar bool) *object.SplitHeader {
 
 	if !empty {
 		m.SetSplitID([]byte{1, 3, 5})
+		m.SetParent(refstest.GenerateObjectID(false))
+		m.SetPrevious(refstest.GenerateObjectID(false))
+		m.SetChildren(refstest.GenerateObjectIDs(false))
 	}
 
-	m.SetParent(refstest.GenerateObjectID(empty))
-	m.SetPrevious(refstest.GenerateObjectID(empty))
 	m.SetParentSignature(refstest.GenerateSignature(empty))
-	m.SetChildren(refstest.GenerateObjectIDs(empty))
 
 	if withPar {
 		m.SetParentHeader(generateHeader(empty, false))
@@ -79,15 +81,15 @@ func generateHeader(empty, withSplit bool) *object.Header {
 		m.SetPayloadLength(777)
 		m.SetCreationEpoch(432)
 		m.SetObjectType(111)
+		m.SetOwnerID(refstest.GenerateOwnerID(false))
+		m.SetContainerID(refstest.GenerateContainerID(false))
+		m.SetAttributes(GenerateAttributes(false))
 	}
 
 	m.SetVersion(refstest.GenerateVersion(empty))
 	m.SetPayloadHash(refstest.GenerateChecksum(empty))
-	m.SetOwnerID(refstest.GenerateOwnerID(empty))
 	m.SetHomomorphicHash(refstest.GenerateChecksum(empty))
-	m.SetContainerID(refstest.GenerateContainerID(empty))
 	m.SetSessionToken(sessiontest.GenerateSessionToken(empty))
-	m.SetAttributes(GenerateAttributes(empty))
 
 	if withSplit {
 		m.SetSplit(generateSplitHeader(empty, false))
@@ -110,9 +112,9 @@ func GenerateObject(empty bool) *object.Object {
 
 	if !empty {
 		m.SetPayload([]byte{7, 8, 9})
+		m.SetObjectID(refstest.GenerateObjectID(false))
 	}
 
-	m.SetObjectID(refstest.GenerateObjectID(empty))
 	m.SetSignature(refstest.GenerateSignature(empty))
 	m.SetHeader(GenerateHeader(empty))
 
@@ -124,10 +126,9 @@ func GenerateSplitInfo(empty bool) *object.SplitInfo {
 
 	if !empty {
 		m.SetSplitID([]byte("splitID"))
+		m.SetLastPart(refstest.GenerateObjectID(false))
+		m.SetLink(refstest.GenerateObjectID(false))
 	}
-
-	m.SetLastPart(refstest.GenerateObjectID(empty))
-	m.SetLink(refstest.GenerateObjectID(empty))
 
 	return m
 }
@@ -137,9 +138,8 @@ func GenerateGetRequestBody(empty bool) *object.GetRequestBody {
 
 	if !empty {
 		m.SetRaw(true)
+		m.SetAddress(refstest.GenerateAddress(false))
 	}
-
-	m.SetAddress(refstest.GenerateAddress(empty))
 
 	return m
 }
@@ -147,7 +147,10 @@ func GenerateGetRequestBody(empty bool) *object.GetRequestBody {
 func GenerateGetRequest(empty bool) *object.GetRequest {
 	m := new(object.GetRequest)
 
-	m.SetBody(GenerateGetRequestBody(empty))
+	if !empty {
+		m.SetBody(GenerateGetRequestBody(false))
+	}
+
 	m.SetMetaHeader(sessiontest.GenerateRequestMetaHeader(empty))
 	m.SetVerificationHeader(sessiontest.GenerateRequestVerificationHeader(empty))
 
@@ -157,7 +160,10 @@ func GenerateGetRequest(empty bool) *object.GetRequest {
 func GenerateGetObjectPartInit(empty bool) *object.GetObjectPartInit {
 	m := new(object.GetObjectPartInit)
 
-	m.SetObjectID(refstest.GenerateObjectID(empty))
+	if !empty {
+		m.SetObjectID(refstest.GenerateObjectID(false))
+	}
+
 	m.SetSignature(refstest.GenerateSignature(empty))
 	m.SetHeader(GenerateHeader(empty))
 
@@ -177,7 +183,9 @@ func GenerateGetObjectPartChunk(empty bool) *object.GetObjectPartChunk {
 func GenerateGetResponseBody(empty bool) *object.GetResponseBody {
 	m := new(object.GetResponseBody)
 
-	m.SetObjectPart(GenerateGetObjectPartInit(empty))
+	if !empty {
+		m.SetObjectPart(GenerateGetObjectPartInit(false))
+	}
 
 	return m
 }
@@ -185,7 +193,10 @@ func GenerateGetResponseBody(empty bool) *object.GetResponseBody {
 func GenerateGetResponse(empty bool) *object.GetResponse {
 	m := new(object.GetResponse)
 
-	m.SetBody(GenerateGetResponseBody(empty))
+	if !empty {
+		m.SetBody(GenerateGetResponseBody(false))
+	}
+
 	m.SetMetaHeader(sessiontest.GenerateResponseMetaHeader(empty))
 	m.SetVerificationHeader(sessiontest.GenerateResponseVerificationHeader(empty))
 
@@ -197,9 +208,9 @@ func GeneratePutObjectPartInit(empty bool) *object.PutObjectPartInit {
 
 	if !empty {
 		m.SetCopiesNumber(234)
+		m.SetObjectID(refstest.GenerateObjectID(false))
 	}
 
-	m.SetObjectID(refstest.GenerateObjectID(empty))
 	m.SetSignature(refstest.GenerateSignature(empty))
 	m.SetHeader(GenerateHeader(empty))
 
@@ -219,7 +230,9 @@ func GeneratePutObjectPartChunk(empty bool) *object.PutObjectPartChunk {
 func GeneratePutRequestBody(empty bool) *object.PutRequestBody {
 	m := new(object.PutRequestBody)
 
-	m.SetObjectPart(GeneratePutObjectPartInit(empty))
+	if !empty {
+		m.SetObjectPart(GeneratePutObjectPartInit(false))
+	}
 
 	return m
 }
@@ -227,7 +240,10 @@ func GeneratePutRequestBody(empty bool) *object.PutRequestBody {
 func GeneratePutRequest(empty bool) *object.PutRequest {
 	m := new(object.PutRequest)
 
-	m.SetBody(GeneratePutRequestBody(empty))
+	if !empty {
+		m.SetBody(GeneratePutRequestBody(false))
+	}
+
 	m.SetMetaHeader(sessiontest.GenerateRequestMetaHeader(empty))
 	m.SetVerificationHeader(sessiontest.GenerateRequestVerificationHeader(empty))
 
@@ -237,7 +253,9 @@ func GeneratePutRequest(empty bool) *object.PutRequest {
 func GeneratePutResponseBody(empty bool) *object.PutResponseBody {
 	m := new(object.PutResponseBody)
 
-	m.SetObjectID(refstest.GenerateObjectID(empty))
+	if !empty {
+		m.SetObjectID(refstest.GenerateObjectID(false))
+	}
 
 	return m
 }
@@ -245,7 +263,10 @@ func GeneratePutResponseBody(empty bool) *object.PutResponseBody {
 func GeneratePutResponse(empty bool) *object.PutResponse {
 	m := new(object.PutResponse)
 
-	m.SetBody(GeneratePutResponseBody(empty))
+	if !empty {
+		m.SetBody(GeneratePutResponseBody(false))
+	}
+
 	m.SetMetaHeader(sessiontest.GenerateResponseMetaHeader(empty))
 	m.SetVerificationHeader(sessiontest.GenerateResponseVerificationHeader(empty))
 
@@ -255,7 +276,9 @@ func GeneratePutResponse(empty bool) *object.PutResponse {
 func GenerateDeleteRequestBody(empty bool) *object.DeleteRequestBody {
 	m := new(object.DeleteRequestBody)
 
-	m.SetAddress(refstest.GenerateAddress(empty))
+	if !empty {
+		m.SetAddress(refstest.GenerateAddress(false))
+	}
 
 	return m
 }
@@ -263,7 +286,10 @@ func GenerateDeleteRequestBody(empty bool) *object.DeleteRequestBody {
 func GenerateDeleteRequest(empty bool) *object.DeleteRequest {
 	m := new(object.DeleteRequest)
 
-	m.SetBody(GenerateDeleteRequestBody(empty))
+	if !empty {
+		m.SetBody(GenerateDeleteRequestBody(false))
+	}
+
 	m.SetMetaHeader(sessiontest.GenerateRequestMetaHeader(empty))
 	m.SetVerificationHeader(sessiontest.GenerateRequestVerificationHeader(empty))
 
@@ -273,7 +299,9 @@ func GenerateDeleteRequest(empty bool) *object.DeleteRequest {
 func GenerateDeleteResponseBody(empty bool) *object.DeleteResponseBody {
 	m := new(object.DeleteResponseBody)
 
-	m.SetTombstone(refstest.GenerateAddress(empty))
+	if !empty {
+		m.SetTombstone(refstest.GenerateAddress(false))
+	}
 
 	return m
 }
@@ -281,7 +309,10 @@ func GenerateDeleteResponseBody(empty bool) *object.DeleteResponseBody {
 func GenerateDeleteResponse(empty bool) *object.DeleteResponse {
 	m := new(object.DeleteResponse)
 
-	m.SetBody(GenerateDeleteResponseBody(empty))
+	if !empty {
+		m.SetBody(GenerateDeleteResponseBody(false))
+	}
+
 	m.SetMetaHeader(sessiontest.GenerateResponseMetaHeader(empty))
 	m.SetVerificationHeader(sessiontest.GenerateResponseVerificationHeader(empty))
 
@@ -294,9 +325,8 @@ func GenerateHeadRequestBody(empty bool) *object.HeadRequestBody {
 	if !empty {
 		m.SetRaw(true)
 		m.SetMainOnly(true)
+		m.SetAddress(refstest.GenerateAddress(false))
 	}
-
-	m.SetAddress(refstest.GenerateAddress(empty))
 
 	return m
 }
@@ -304,7 +334,10 @@ func GenerateHeadRequestBody(empty bool) *object.HeadRequestBody {
 func GenerateHeadRequest(empty bool) *object.HeadRequest {
 	m := new(object.HeadRequest)
 
-	m.SetBody(GenerateHeadRequestBody(empty))
+	if !empty {
+		m.SetBody(GenerateHeadRequestBody(false))
+	}
+
 	m.SetMetaHeader(sessiontest.GenerateRequestMetaHeader(empty))
 	m.SetVerificationHeader(sessiontest.GenerateRequestVerificationHeader(empty))
 
@@ -314,7 +347,9 @@ func GenerateHeadRequest(empty bool) *object.HeadRequest {
 func GenerateHeadResponseBody(empty bool) *object.HeadResponseBody {
 	m := new(object.HeadResponseBody)
 
-	m.SetHeaderPart(GenerateHeaderWithSignature(empty))
+	if !empty {
+		m.SetHeaderPart(GenerateHeaderWithSignature(false))
+	}
 
 	return m
 }
@@ -322,7 +357,10 @@ func GenerateHeadResponseBody(empty bool) *object.HeadResponseBody {
 func GenerateHeadResponse(empty bool) *object.HeadResponse {
 	m := new(object.HeadResponse)
 
-	m.SetBody(GenerateHeadResponseBody(empty))
+	if !empty {
+		m.SetBody(GenerateHeadResponseBody(false))
+	}
+
 	m.SetMetaHeader(sessiontest.GenerateResponseMetaHeader(empty))
 	m.SetVerificationHeader(sessiontest.GenerateResponseVerificationHeader(empty))
 
@@ -341,7 +379,9 @@ func GenerateSearchFilter(empty bool) *object.SearchFilter {
 	return m
 }
 
-func GenerateSearchFilters(empty bool) (res []*object.SearchFilter) {
+func GenerateSearchFilters(empty bool) []*object.SearchFilter {
+	var res []*object.SearchFilter
+
 	if !empty {
 		res = append(res,
 			GenerateSearchFilter(false),
@@ -349,7 +389,7 @@ func GenerateSearchFilters(empty bool) (res []*object.SearchFilter) {
 		)
 	}
 
-	return
+	return res
 }
 
 func GenerateSearchRequestBody(empty bool) *object.SearchRequestBody {
@@ -357,10 +397,9 @@ func GenerateSearchRequestBody(empty bool) *object.SearchRequestBody {
 
 	if !empty {
 		m.SetVersion(555)
+		m.SetContainerID(refstest.GenerateContainerID(false))
+		m.SetFilters(GenerateSearchFilters(false))
 	}
-
-	m.SetContainerID(refstest.GenerateContainerID(empty))
-	m.SetFilters(GenerateSearchFilters(empty))
 
 	return m
 }
@@ -368,7 +407,10 @@ func GenerateSearchRequestBody(empty bool) *object.SearchRequestBody {
 func GenerateSearchRequest(empty bool) *object.SearchRequest {
 	m := new(object.SearchRequest)
 
-	m.SetBody(GenerateSearchRequestBody(empty))
+	if !empty {
+		m.SetBody(GenerateSearchRequestBody(false))
+	}
+
 	m.SetMetaHeader(sessiontest.GenerateRequestMetaHeader(empty))
 	m.SetVerificationHeader(sessiontest.GenerateRequestVerificationHeader(empty))
 
@@ -378,7 +420,9 @@ func GenerateSearchRequest(empty bool) *object.SearchRequest {
 func GenerateSearchResponseBody(empty bool) *object.SearchResponseBody {
 	m := new(object.SearchResponseBody)
 
-	m.SetIDList(refstest.GenerateObjectIDs(empty))
+	if !empty {
+		m.SetIDList(refstest.GenerateObjectIDs(false))
+	}
 
 	return m
 }
@@ -386,7 +430,10 @@ func GenerateSearchResponseBody(empty bool) *object.SearchResponseBody {
 func GenerateSearchResponse(empty bool) *object.SearchResponse {
 	m := new(object.SearchResponse)
 
-	m.SetBody(GenerateSearchResponseBody(empty))
+	if !empty {
+		m.SetBody(GenerateSearchResponseBody(false))
+	}
+
 	m.SetMetaHeader(sessiontest.GenerateResponseMetaHeader(empty))
 	m.SetVerificationHeader(sessiontest.GenerateResponseVerificationHeader(empty))
 
@@ -404,7 +451,9 @@ func GenerateRange(empty bool) *object.Range {
 	return m
 }
 
-func GenerateRanges(empty bool) (res []*object.Range) {
+func GenerateRanges(empty bool) []*object.Range {
+	var res []*object.Range
+
 	if !empty {
 		res = append(res,
 			GenerateRange(false),
@@ -412,7 +461,7 @@ func GenerateRanges(empty bool) (res []*object.Range) {
 		)
 	}
 
-	return
+	return res
 }
 
 func GenerateGetRangeRequestBody(empty bool) *object.GetRangeRequestBody {
@@ -420,10 +469,9 @@ func GenerateGetRangeRequestBody(empty bool) *object.GetRangeRequestBody {
 
 	if !empty {
 		m.SetRaw(true)
+		m.SetAddress(refstest.GenerateAddress(empty))
+		m.SetRange(GenerateRange(empty))
 	}
-
-	m.SetAddress(refstest.GenerateAddress(empty))
-	m.SetRange(GenerateRange(empty))
 
 	return m
 }
@@ -431,7 +479,10 @@ func GenerateGetRangeRequestBody(empty bool) *object.GetRangeRequestBody {
 func GenerateGetRangeRequest(empty bool) *object.GetRangeRequest {
 	m := new(object.GetRangeRequest)
 
-	m.SetBody(GenerateGetRangeRequestBody(empty))
+	if !empty {
+		m.SetBody(GenerateGetRangeRequestBody(false))
+	}
+
 	m.SetMetaHeader(sessiontest.GenerateRequestMetaHeader(empty))
 	m.SetVerificationHeader(sessiontest.GenerateRequestVerificationHeader(empty))
 
@@ -451,7 +502,9 @@ func GenerateGetRangePartChunk(empty bool) *object.GetRangePartChunk {
 func GenerateGetRangeResponseBody(empty bool) *object.GetRangeResponseBody {
 	m := new(object.GetRangeResponseBody)
 
-	m.SetRangePart(GenerateGetRangePartChunk(empty))
+	if !empty {
+		m.SetRangePart(GenerateGetRangePartChunk(false))
+	}
 
 	return m
 }
@@ -459,7 +512,10 @@ func GenerateGetRangeResponseBody(empty bool) *object.GetRangeResponseBody {
 func GenerateGetRangeResponse(empty bool) *object.GetRangeResponse {
 	m := new(object.GetRangeResponse)
 
-	m.SetBody(GenerateGetRangeResponseBody(empty))
+	if !empty {
+		m.SetBody(GenerateGetRangeResponseBody(false))
+	}
+
 	m.SetMetaHeader(sessiontest.GenerateResponseMetaHeader(empty))
 	m.SetVerificationHeader(sessiontest.GenerateResponseVerificationHeader(empty))
 
@@ -472,10 +528,9 @@ func GenerateGetRangeHashRequestBody(empty bool) *object.GetRangeHashRequestBody
 	if !empty {
 		m.SetSalt([]byte("range hash salt"))
 		m.SetType(455)
+		m.SetAddress(refstest.GenerateAddress(false))
+		m.SetRanges(GenerateRanges(false))
 	}
-
-	m.SetAddress(refstest.GenerateAddress(empty))
-	m.SetRanges(GenerateRanges(empty))
 
 	return m
 }
@@ -483,7 +538,10 @@ func GenerateGetRangeHashRequestBody(empty bool) *object.GetRangeHashRequestBody
 func GenerateGetRangeHashRequest(empty bool) *object.GetRangeHashRequest {
 	m := new(object.GetRangeHashRequest)
 
-	m.SetBody(GenerateGetRangeHashRequestBody(empty))
+	if !empty {
+		m.SetBody(GenerateGetRangeHashRequestBody(false))
+	}
+
 	m.SetMetaHeader(sessiontest.GenerateRequestMetaHeader(empty))
 	m.SetVerificationHeader(sessiontest.GenerateRequestVerificationHeader(empty))
 
@@ -504,7 +562,10 @@ func GenerateGetRangeHashResponseBody(empty bool) *object.GetRangeHashResponseBo
 func GenerateGetRangeHashResponse(empty bool) *object.GetRangeHashResponse {
 	m := new(object.GetRangeHashResponse)
 
-	m.SetBody(GenerateGetRangeHashResponseBody(empty))
+	if !empty {
+		m.SetBody(GenerateGetRangeHashResponseBody(false))
+	}
+
 	m.SetMetaHeader(sessiontest.GenerateResponseMetaHeader(empty))
 	m.SetVerificationHeader(sessiontest.GenerateResponseVerificationHeader(empty))
 

--- a/v2/refs/test/generate.go
+++ b/v2/refs/test/generate.go
@@ -28,8 +28,10 @@ func GenerateOwnerID(empty bool) *refs.OwnerID {
 func GenerateAddress(empty bool) *refs.Address {
 	m := new(refs.Address)
 
-	m.SetObjectID(GenerateObjectID(empty))
-	m.SetContainerID(GenerateContainerID(empty))
+	if !empty {
+		m.SetObjectID(GenerateObjectID(false))
+		m.SetContainerID(GenerateContainerID(false))
+	}
 
 	return m
 }
@@ -45,7 +47,7 @@ func GenerateObjectID(empty bool) *refs.ObjectID {
 }
 
 func GenerateObjectIDs(empty bool) []*refs.ObjectID {
-	ids := make([]*refs.ObjectID, 0)
+	var ids []*refs.ObjectID
 
 	if !empty {
 		ids = append(ids,
@@ -67,7 +69,9 @@ func GenerateContainerID(empty bool) *refs.ContainerID {
 	return m
 }
 
-func GenerateContainerIDs(empty bool) (res []*refs.ContainerID) {
+func GenerateContainerIDs(empty bool) []*refs.ContainerID {
+	var res []*refs.ContainerID
+
 	if !empty {
 		res = append(res,
 			GenerateContainerID(false),
@@ -75,7 +79,7 @@ func GenerateContainerIDs(empty bool) (res []*refs.ContainerID) {
 		)
 	}
 
-	return
+	return res
 }
 
 func GenerateSignature(empty bool) *refs.Signature {

--- a/v2/reputation/test/generate.go
+++ b/v2/reputation/test/generate.go
@@ -21,9 +21,8 @@ func GenerateTrust(empty bool) *reputation.Trust {
 
 	if !empty {
 		m.SetValue(1)
+		m.SetPeer(GeneratePeerID(false))
 	}
-
-	m.SetPeer(GeneratePeerID(empty))
 
 	return m
 }
@@ -31,8 +30,10 @@ func GenerateTrust(empty bool) *reputation.Trust {
 func GeneratePeerToPeerTrust(empty bool) *reputation.PeerToPeerTrust {
 	m := new(reputation.PeerToPeerTrust)
 
-	m.SetTrustingPeer(GeneratePeerID(empty))
-	m.SetTrust(GenerateTrust(empty))
+	if !empty {
+		m.SetTrustingPeer(GeneratePeerID(false))
+		m.SetTrust(GenerateTrust(false))
+	}
 
 	return m
 }
@@ -40,8 +41,10 @@ func GeneratePeerToPeerTrust(empty bool) *reputation.PeerToPeerTrust {
 func GenerateGlobalTrustBody(empty bool) *reputation.GlobalTrustBody {
 	m := new(reputation.GlobalTrustBody)
 
-	m.SetManager(GeneratePeerID(empty))
-	m.SetTrust(GenerateTrust(empty))
+	if !empty {
+		m.SetManager(GeneratePeerID(false))
+		m.SetTrust(GenerateTrust(false))
+	}
 
 	return m
 }
@@ -49,14 +52,18 @@ func GenerateGlobalTrustBody(empty bool) *reputation.GlobalTrustBody {
 func GenerateGlobalTrust(empty bool) *reputation.GlobalTrust {
 	m := new(reputation.GlobalTrust)
 
-	m.SetVersion(refstest.GenerateVersion(empty))
-	m.SetBody(GenerateGlobalTrustBody(empty))
-	m.SetSignature(refstest.GenerateSignature(empty))
+	if !empty {
+		m.SetVersion(refstest.GenerateVersion(false))
+		m.SetBody(GenerateGlobalTrustBody(false))
+		m.SetSignature(refstest.GenerateSignature(empty))
+	}
 
 	return m
 }
 
-func GenerateTrusts(empty bool) (res []*reputation.Trust) {
+func GenerateTrusts(empty bool) []*reputation.Trust {
+	var res []*reputation.Trust
+
 	if !empty {
 		res = append(res,
 			GenerateTrust(false),
@@ -64,7 +71,7 @@ func GenerateTrusts(empty bool) (res []*reputation.Trust) {
 		)
 	}
 
-	return
+	return res
 }
 
 func GenerateAnnounceLocalTrustRequestBody(empty bool) *reputation.AnnounceLocalTrustRequestBody {
@@ -72,9 +79,8 @@ func GenerateAnnounceLocalTrustRequestBody(empty bool) *reputation.AnnounceLocal
 
 	if !empty {
 		m.SetEpoch(13)
+		m.SetTrusts(GenerateTrusts(false))
 	}
-
-	m.SetTrusts(GenerateTrusts(empty))
 
 	return m
 }
@@ -82,9 +88,11 @@ func GenerateAnnounceLocalTrustRequestBody(empty bool) *reputation.AnnounceLocal
 func GenerateAnnounceLocalTrustRequest(empty bool) *reputation.AnnounceLocalTrustRequest {
 	m := new(reputation.AnnounceLocalTrustRequest)
 
-	m.SetBody(GenerateAnnounceLocalTrustRequestBody(empty))
-	m.SetMetaHeader(sessiontest.GenerateRequestMetaHeader(empty))
-	m.SetVerificationHeader(sessiontest.GenerateRequestVerificationHeader(empty))
+	if !empty {
+		m.SetBody(GenerateAnnounceLocalTrustRequestBody(false))
+		m.SetMetaHeader(sessiontest.GenerateRequestMetaHeader(empty))
+		m.SetVerificationHeader(sessiontest.GenerateRequestVerificationHeader(empty))
+	}
 
 	return m
 }
@@ -98,9 +106,11 @@ func GenerateAnnounceLocalTrustResponseBody(empty bool) *reputation.AnnounceLoca
 func GenerateAnnounceLocalTrustResponse(empty bool) *reputation.AnnounceLocalTrustResponse {
 	m := new(reputation.AnnounceLocalTrustResponse)
 
-	m.SetBody(GenerateAnnounceLocalTrustResponseBody(empty))
-	m.SetMetaHeader(sessiontest.GenerateResponseMetaHeader(empty))
-	m.SetVerificationHeader(sessiontest.GenerateResponseVerificationHeader(empty))
+	if !empty {
+		m.SetBody(GenerateAnnounceLocalTrustResponseBody(false))
+		m.SetMetaHeader(sessiontest.GenerateResponseMetaHeader(empty))
+		m.SetVerificationHeader(sessiontest.GenerateResponseVerificationHeader(empty))
+	}
 
 	return m
 }
@@ -111,7 +121,7 @@ func GenerateAnnounceIntermediateResultRequestBody(empty bool) *reputation.Annou
 	if !empty {
 		m.SetEpoch(123)
 		m.SetIteration(564)
-		m.SetTrust(GeneratePeerToPeerTrust(empty))
+		m.SetTrust(GeneratePeerToPeerTrust(false))
 	}
 
 	return m
@@ -120,7 +130,10 @@ func GenerateAnnounceIntermediateResultRequestBody(empty bool) *reputation.Annou
 func GenerateAnnounceIntermediateResultRequest(empty bool) *reputation.AnnounceIntermediateResultRequest {
 	m := new(reputation.AnnounceIntermediateResultRequest)
 
-	m.SetBody(GenerateAnnounceIntermediateResultRequestBody(empty))
+	if !empty {
+		m.SetBody(GenerateAnnounceIntermediateResultRequestBody(false))
+	}
+
 	m.SetMetaHeader(sessiontest.GenerateRequestMetaHeader(empty))
 	m.SetVerificationHeader(sessiontest.GenerateRequestVerificationHeader(empty))
 
@@ -136,7 +149,10 @@ func GenerateAnnounceIntermediateResultResponseBody(empty bool) *reputation.Anno
 func GenerateAnnounceIntermediateResultResponse(empty bool) *reputation.AnnounceIntermediateResultResponse {
 	m := new(reputation.AnnounceIntermediateResultResponse)
 
-	m.SetBody(GenerateAnnounceIntermediateResultResponseBody(empty))
+	if !empty {
+		m.SetBody(GenerateAnnounceIntermediateResultResponseBody(false))
+	}
+
 	m.SetMetaHeader(sessiontest.GenerateResponseMetaHeader(empty))
 	m.SetVerificationHeader(sessiontest.GenerateResponseVerificationHeader(empty))
 

--- a/v2/session/test/generate.go
+++ b/v2/session/test/generate.go
@@ -11,9 +11,8 @@ func GenerateCreateRequestBody(empty bool) *session.CreateRequestBody {
 
 	if !empty {
 		m.SetExpiration(555)
+		m.SetOwnerID(refstest.GenerateOwnerID(false))
 	}
-
-	m.SetOwnerID(refstest.GenerateOwnerID(empty))
 
 	return m
 }
@@ -21,7 +20,10 @@ func GenerateCreateRequestBody(empty bool) *session.CreateRequestBody {
 func GenerateCreateRequest(empty bool) *session.CreateRequest {
 	m := new(session.CreateRequest)
 
-	m.SetBody(GenerateCreateRequestBody(empty))
+	if !empty {
+		m.SetBody(GenerateCreateRequestBody(false))
+	}
+
 	m.SetMetaHeader(GenerateRequestMetaHeader(empty))
 	m.SetVerificationHeader(GenerateRequestVerificationHeader(empty))
 
@@ -42,7 +44,10 @@ func GenerateCreateResponseBody(empty bool) *session.CreateResponseBody {
 func GenerateCreateResponse(empty bool) *session.CreateResponse {
 	m := new(session.CreateResponse)
 
-	m.SetBody(GenerateCreateResponseBody(empty))
+	if !empty {
+		m.SetBody(GenerateCreateResponseBody(false))
+	}
+
 	m.SetMetaHeader(GenerateResponseMetaHeader(empty))
 	m.SetVerificationHeader(GenerateResponseVerificationHeader(empty))
 
@@ -56,7 +61,10 @@ func GenerateResponseVerificationHeader(empty bool) *session.ResponseVerificatio
 func generateResponseVerificationHeader(empty, withOrigin bool) *session.ResponseVerificationHeader {
 	m := new(session.ResponseVerificationHeader)
 
-	m.SetBodySignature(refstest.GenerateSignature(empty))
+	if !empty {
+		m.SetBodySignature(refstest.GenerateSignature(false))
+	}
+
 	m.SetMetaSignature(refstest.GenerateSignature(empty))
 	m.SetOriginSignature(refstest.GenerateSignature(empty))
 
@@ -96,7 +104,10 @@ func GenerateRequestVerificationHeader(empty bool) *session.RequestVerificationH
 func generateRequestVerificationHeader(empty, withOrigin bool) *session.RequestVerificationHeader {
 	m := new(session.RequestVerificationHeader)
 
-	m.SetBodySignature(refstest.GenerateSignature(empty))
+	if !empty {
+		m.SetBodySignature(refstest.GenerateSignature(false))
+	}
+
 	m.SetMetaSignature(refstest.GenerateSignature(empty))
 	m.SetOriginSignature(refstest.GenerateSignature(empty))
 
@@ -134,7 +145,10 @@ func generateRequestMetaHeader(empty, withOrigin bool) *session.RequestMetaHeade
 func GenerateSessionToken(empty bool) *session.SessionToken {
 	m := new(session.SessionToken)
 
-	m.SetBody(GenerateSessionTokenBody(empty))
+	if !empty {
+		m.SetBody(GenerateSessionTokenBody(false))
+	}
+
 	m.SetSignature(refstest.GenerateSignature(empty))
 
 	return m
@@ -146,11 +160,10 @@ func GenerateSessionTokenBody(empty bool) *session.SessionTokenBody {
 	if !empty {
 		m.SetID([]byte{1})
 		m.SetSessionKey([]byte{2})
+		m.SetOwnerID(refstest.GenerateOwnerID(false))
+		m.SetLifetime(GenerateTokenLifetime(false))
+		m.SetContext(GenerateObjectSessionContext(false))
 	}
-
-	m.SetOwnerID(refstest.GenerateOwnerID(empty))
-	m.SetLifetime(GenerateTokenLifetime(empty))
-	m.SetContext(GenerateObjectSessionContext(empty))
 
 	return m
 }
@@ -172,9 +185,8 @@ func GenerateObjectSessionContext(empty bool) *session.ObjectSessionContext {
 
 	if !empty {
 		m.SetVerb(session.ObjectVerbHead)
+		m.SetAddress(refstest.GenerateAddress(false))
 	}
-
-	m.SetAddress(refstest.GenerateAddress(empty))
 
 	return m
 }
@@ -185,9 +197,8 @@ func GenerateContainerSessionContext(empty bool) *session.ContainerSessionContex
 	if !empty {
 		m.SetVerb(session.ContainerVerbDelete)
 		m.SetWildcard(true)
+		m.SetContainerID(refstest.GenerateContainerID(false))
 	}
-
-	m.SetContainerID(refstest.GenerateContainerID(empty))
 
 	return m
 }
@@ -204,7 +215,7 @@ func GenerateXHeader(empty bool) *session.XHeader {
 }
 
 func GenerateXHeaders(empty bool) []*session.XHeader {
-	xs := make([]*session.XHeader, 0)
+	var xs []*session.XHeader
 
 	if !empty {
 		xs = append(xs,

--- a/v2/storagegroup/test/generate.go
+++ b/v2/storagegroup/test/generate.go
@@ -11,10 +11,10 @@ func GenerateStorageGroup(empty bool) *storagegroup.StorageGroup {
 	if !empty {
 		m.SetValidationDataSize(44)
 		m.SetExpirationEpoch(55)
+		m.SetMembers(refstest.GenerateObjectIDs(false))
 	}
 
 	m.SetValidationHash(refstest.GenerateChecksum(empty))
-	m.SetMembers(refstest.GenerateObjectIDs(empty))
 
 	return m
 }

--- a/v2/tombstone/test/generate.go
+++ b/v2/tombstone/test/generate.go
@@ -11,9 +11,8 @@ func GenerateTombstone(empty bool) *tombstone.Tombstone {
 	if !empty {
 		m.SetExpirationEpoch(89)
 		m.SetSplitID([]byte{3, 2, 1})
+		m.SetMembers(refstest.GenerateObjectIDs(false))
 	}
-
-	m.SetMembers(refstest.GenerateObjectIDs(empty))
 
 	return m
 }


### PR DESCRIPTION
Move all memory allocation and field settings in `GenerateTYPE(empty bool) *TYPE` functions behind `if !empty` check. Exceptions: meta fields such as signatures, hashes, headers, etc, since it seems that such fields are not going to be filled/edited manually in unit tests but at the same time obtaining "true" empty structures is equivalent to just `new(TYPE)`.

Related to #276.