### PR TITLE
Fix well-known BasicACL constants to fit the spec

### DIFF
--- a/pkg/acl/types.go
+++ b/pkg/acl/types.go
@@ -1,12 +1,12 @@
 package acl
 
 const (
-	// PublicBasicRule is a basic ACL value for public container.
-	PublicBasicRule = 0x1FFFFFFF
+	// PublicBasicRule is a basic ACL value for public-read-write container.
+	PublicBasicRule = 0x1FBFBFFF
 
 	// PrivateBasicRule is a basic ACL value for private container.
-	PrivateBasicRule = 0x18888888
+	PrivateBasicRule = 0x1C8C8CCC
 
-	// ReadOnlyBasicRule is a basic ACL value for read-only container.
-	ReadOnlyBasicRule = 0x1FFF88FF
+	// ReadOnlyBasicRule is a basic ACL value for public-read container.
+	ReadOnlyBasicRule = 0x1FBFBFFF
 )


### PR DESCRIPTION
In the well-known BasicACL constants we need to set the always toggled bits for the system group. Otherwise it may be confusing for those who read the specification and try to match it with the reference implementation or the resulting BasicACL set in the container.