### PR TITLE
Prevent potential NPE in NEO3WalletFromPublicKey

### DIFF
--- a/pkg/owner/wallet.go
+++ b/pkg/owner/wallet.go
@@ -22,8 +22,9 @@ func NEO3WalletFromPublicKey(key *ecdsa.PublicKey) (*NEO3Wallet, error) {
 	}
 
 	neoPublicKey := keys.PublicKey{
-		X: key.X,
-		Y: key.Y,
+		Curve: key.Curve,
+		X:     key.X,
+		Y:     key.Y,
 	}
 
 	d, err := base58.Decode(neoPublicKey.Address())


### PR DESCRIPTION
The bug was detected after local updating of neo-go library which started to use `Curve` field in `PublicKey.Address` method.