### PR TITLE
Fix directory handling in `prepare.sh`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ imports:
 protoc:
 	@GOPRIVATE=github.com/nspcc-dev go mod vendor
 	# Install specific version for protobuf lib
-	@go list -f '{{.Path}}/...@{{.Version}}' -m  google.golang.org/protobuf | xargs go get -v
+	@go list -f '{{.Path}}/...@{{.Version}}' -m  google.golang.org/protobuf | xargs go install -v
 	# Protoc generate
 	@for f in `find . -type f -name '*.proto' -not -path './vendor/*'`; do \
 		echo "⇒ Processing $$f "; \

--- a/prepare.sh
+++ b/prepare.sh
@@ -2,38 +2,38 @@
 
 prefix=v2
 
-if [ -z "$1" ]; then 
+if [ -z "$1" ]; then
     echo "usage: ./prepare.sh path/to/neofs-api"
     exit 1
-fi 
+fi
 
 API_GO_PATH=$(pwd)
-API_PATH=$1 
-mkdir $API_GO_PATH/$prefix 2>/dev/null
+API_PATH=$1
+mkdir "$API_GO_PATH/$prefix" 2>/dev/null
 
 # MOVE FILES FROM API REPO
-cd $API_PATH
+cd "$API_PATH" || exit 1
 ARGS=$(find ./ -name '*.proto' -not -path './vendor/*')
 for file in $ARGS; do
-    dir=$(dirname $file)
-    mkdir -p $API_GO_PATH/$prefix/$dir/grpc
-    cp -r $dir/* $API_GO_PATH/$prefix/$dir/grpc
+	dir=$(dirname "$file")
+	mkdir -p "$API_GO_PATH/$prefix/$dir/grpc"
+	cp -r "$dir"/* "$API_GO_PATH/$prefix/$dir/grpc"
 done
 
 # MODIFY FILES
-cd $API_GO_PATH/$prefix
+cd "$API_GO_PATH/$prefix" || exit 1
 ARGS2=$(find ./ -name '*.proto')
 for file in $ARGS2; do
-    echo $file
-    sed -i "s/import\ \"\(.*\)\/\(.*\)\.proto\";/import\ \"$prefix\/\1\/grpc\/\2\.proto\";/" $file
+	echo "$file"
+	sed -i "s/import\ \"\(.*\)\/\(.*\)\.proto\";/import\ \"$prefix\/\1\/grpc\/\2\.proto\";/" $file
 done
 
-cd $API_GO_PATH
+cd "$API_GO_PATH" || exit 1
 # COMPILE
 make protoc
 
 # REMOVE PROTO DEFINITIONS
 ARGS=$(find ./$prefix -name '*.proto' -not -path './vendor/*')
 for file in $ARGS; do
-    rm $file
+	rm "$file"
 done


### PR DESCRIPTION
1. Use go install in `protoc` target.
`go get: installing executables with 'go get' in module mode is deprecated.`
2. Allow to have whitespaces in directories.
3. Fail early if cd target doesn't exist.