### PR TITLE
[#364] Makefile: Remove deprecated -i flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ dep:
 	@printf "⇒ Install test requirements: "
 	CGO_ENABLED=0 \
 	GO111MODULE=on \
-	go test -i ./... && echo OK
+	go test ./... && echo OK
 
 # Run all code formatters
 fmts: fmt imports


### PR DESCRIPTION
It caused an error in my case: 
```
go test: -i flag is deprecated
go test net: copying /home/kira/.cache/go-build/42/42a7dcda83d6782844dece1e4eb3e1447fa9792df66faa25dfd1f8dc8ef14c52-d: open /usr/lib/go/pkg/linux_amd64/net.a: permission denied
```

Signed-off-by: Angira Kekteeva <kira@nspcc.ru>