### PR TITLE
rpc/grpc: Perform read-write message operations with timeout 

### DIFF
--- a/rpc/client/connect.go
+++ b/rpc/client/connect.go
@@ -15,7 +15,10 @@ func (c *Client) createGRPCClient() (err error) {
 			return
 		}
 
-		c.gRPCClient = grpc.New(grpc.WithClientConnection(c.conn))
+		c.gRPCClient = grpc.New(
+			grpc.WithClientConnection(c.conn),
+			grpc.WithRWTimeout(c.rwTimeout),
+		)
 	})
 
 	return

--- a/rpc/client/options.go
+++ b/rpc/client/options.go
@@ -20,17 +20,22 @@ type cfg struct {
 	addr string
 
 	dialTimeout time.Duration
+	rwTimeout   time.Duration
 
 	tlsCfg *tls.Config
 
 	conn *grpc.ClientConn
 }
 
-const defaultDialTimeout = 5 * time.Second
+const (
+	defaultDialTimeout = 5 * time.Second
+	defaultRWTimeout   = 1 * time.Minute
+)
 
 func defaultCfg() *cfg {
 	return &cfg{
 		dialTimeout: defaultDialTimeout,
+		rwTimeout:   defaultRWTimeout,
 	}
 }
 
@@ -92,6 +97,16 @@ func WithDialTimeout(v time.Duration) Option {
 	return func(c *cfg) {
 		if v > 0 {
 			c.dialTimeout = v
+		}
+	}
+}
+
+// WithRWTimeout returns option to specify timeout
+// for reading and writing single gRPC message.
+func WithRWTimeout(v time.Duration) Option {
+	return func(c *cfg) {
+		if v > 0 {
+			c.rwTimeout = v
 		}
 	}
 }

--- a/rpc/grpc/options.go
+++ b/rpc/grpc/options.go
@@ -1,15 +1,22 @@
 package grpc
 
 import (
+	"time"
+
 	"google.golang.org/grpc"
 )
 
+const defaultRWTimeout = 1 * time.Minute
+
 type cfg struct {
-	con *grpc.ClientConn
+	con       *grpc.ClientConn
+	rwTimeout time.Duration
 }
 
 func defaultCfg() *cfg {
-	return new(cfg)
+	return &cfg{
+		rwTimeout: defaultRWTimeout,
+	}
 }
 
 // WithClientConnection returns option to set gRPC connection
@@ -17,5 +24,13 @@ func defaultCfg() *cfg {
 func WithClientConnection(con *grpc.ClientConn) Option {
 	return func(c *cfg) {
 		c.con = con
+	}
+}
+
+// WithRWTimeout returns option to specify rwTimeout
+// for reading and writing single gRPC message.
+func WithRWTimeout(t time.Duration) Option {
+	return func(c *cfg) {
+		c.rwTimeout = t
 	}
 }


### PR DESCRIPTION
Remote gRPC server may not return or accept data for a while. gRPC solves this issue with timeout in context. However, the context is used for entire gRPC method invocation. Unfortunately the duration of requests with streams can't be estimated easily.

To solve this issue we can specify timeouts for every message read and write. Single message has size limit so timeout can be related to that.
