### PR TITLE
Support `WRONG_MAGIC_NUMBER` status

### DIFF
--- a/status/details.go
+++ b/status/details.go
@@ -1,0 +1,8 @@
+package status
+
+// details for WrongMagicNumber code.
+const (
+	// DetailIDCorrectMagic is an identifier of details with correct network magic
+	// which can be attached to WrongMagicNumber code.
+	DetailIDCorrectMagic = iota
+)

--- a/status/grpc/types.pb.go
+++ b/status/grpc/types.pb.go
@@ -124,7 +124,10 @@ const (
 	// If the server cannot match failed outcome to the code, it should
 	// use this code.
 	CommonFail_INTERNAL CommonFail = 0
-	// [**1025**] Wrong magic of the NeoFS network. Not detailed.
+	// [**1025**] Wrong magic of the NeoFS network.
+	// Details:
+	//  - [**0**] Magic number of the served NeoFS network (big-endian 64-bit
+	//  unsigned integer).
 	CommonFail_WRONG_MAGIC_NUMBER CommonFail = 1
 )
 

--- a/status/status.go
+++ b/status/status.go
@@ -57,6 +57,8 @@ const (
 const (
 	// Internal is a local Code value for INTERNAL failure status.
 	Internal Code = iota
+	// WrongMagicNumber is a local Code value for WRONG_MAGIC_NUMBER failure status.
+	WrongMagicNumber
 )
 
 const (

--- a/status/test/generate.go
+++ b/status/test/generate.go
@@ -37,7 +37,7 @@ func Status(empty bool) *status.Status {
 	if !empty {
 		m.SetCode(765)
 		m.SetMessage("some string")
-		m.SetDetails(Details(false))
+		status.SetStatusDetails(m, Details(false))
 	}
 
 	return m

--- a/status/types.go
+++ b/status/types.go
@@ -106,9 +106,22 @@ func (x *Status) IterateDetails(f func(*Detail) bool) {
 	}
 }
 
-// SetDetails sets Detail list of the Status.
-func (x *Status) SetDetails(v []*Detail) {
+// ResetDetails empties the detail list.
+func (x *Status) ResetDetails() {
 	if x != nil {
-		x.details = v
+		x.details = x.details[:0]
 	}
+}
+
+// AppendDetails appends the list of details to the Status.
+func (x *Status) AppendDetails(ds ...*Detail) {
+	if x != nil {
+		x.details = append(x.details, ds...)
+	}
+}
+
+// SetStatusDetails sets Detail list of the Status.
+func SetStatusDetails(dst *Status, ds []*Detail) {
+	dst.ResetDetails()
+	dst.AppendDetails(ds...)
 }


### PR DESCRIPTION
I checked that method removal doesn't break the compatibility and decided to not mark it deprecated.