### PR TITLE
acl,object: Add new `MatchType` enum values after protocol extension

### DIFF
--- a/acl/convert.go
+++ b/acl/convert.go
@@ -135,10 +135,15 @@ func HeaderTypeFromGRPCField(t acl.HeaderType) HeaderType {
 // MatchTypeToGRPCField converts unified match type enum into grpc enum.
 func MatchTypeToGRPCField(t MatchType) acl.MatchType {
 	switch t {
-	case MatchTypeStringEqual:
-		return acl.MatchType_STRING_EQUAL
-	case MatchTypeStringNotEqual:
-		return acl.MatchType_STRING_NOT_EQUAL
+	case
+		MatchTypeStringEqual,
+		MatchTypeStringNotEqual,
+		MatchTypeNotPresent,
+		MatchTypeNumGT,
+		MatchTypeNumGE,
+		MatchTypeNumLT,
+		MatchTypeNumLE:
+		return acl.MatchType(t)
 	default:
 		return acl.MatchType_MATCH_TYPE_UNSPECIFIED
 	}
@@ -147,10 +152,15 @@ func MatchTypeToGRPCField(t MatchType) acl.MatchType {
 // MatchTypeFromGRPCField converts grpc enum into unified match type enum.
 func MatchTypeFromGRPCField(t acl.MatchType) MatchType {
 	switch t {
-	case acl.MatchType_STRING_EQUAL:
-		return MatchTypeStringEqual
-	case acl.MatchType_STRING_NOT_EQUAL:
-		return MatchTypeStringNotEqual
+	case
+		acl.MatchType_STRING_EQUAL,
+		acl.MatchType_STRING_NOT_EQUAL,
+		acl.MatchType_NOT_PRESENT,
+		acl.MatchType_NUM_GT,
+		acl.MatchType_NUM_GE,
+		acl.MatchType_NUM_LT,
+		acl.MatchType_NUM_LE:
+		return MatchType(t)
 	default:
 		return MatchTypeUnknown
 	}

--- a/acl/types.go
+++ b/acl/types.go
@@ -79,6 +79,12 @@ const (
 	MatchTypeUnknown MatchType = iota
 	MatchTypeStringEqual
 	MatchTypeStringNotEqual
+	MatchTypeNotPresent
+	MatchTypeNumGT
+	MatchTypeNumGE
+	MatchTypeNumLT
+	MatchTypeNumLE
+	matchTypeLast // for testing
 )
 
 const (

--- a/acl/types_test.go
+++ b/acl/types_test.go
@@ -1,0 +1,30 @@
+package acl
+
+import (
+	"testing"
+
+	acl "github.com/nspcc-dev/neofs-api-go/v2/acl/grpc"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMatchTypeToGRPCField(t *testing.T) {
+	require.Equal(t, MatchTypeUnknown, MatchTypeFromGRPCField(acl.MatchType_NUM_LE+1))
+	require.Equal(t, acl.MatchType_MATCH_TYPE_UNSPECIFIED, MatchTypeToGRPCField(matchTypeLast))
+
+	for _, tc := range []struct {
+		m MatchType
+		g acl.MatchType
+	}{
+		{MatchTypeUnknown, acl.MatchType_MATCH_TYPE_UNSPECIFIED},
+		{MatchTypeStringEqual, acl.MatchType_STRING_EQUAL},
+		{MatchTypeStringNotEqual, acl.MatchType_STRING_NOT_EQUAL},
+		{MatchTypeNotPresent, acl.MatchType_NOT_PRESENT},
+		{MatchTypeNumGT, acl.MatchType_NUM_GT},
+		{MatchTypeNumGE, acl.MatchType_NUM_GE},
+		{MatchTypeNumLT, acl.MatchType_NUM_LT},
+		{MatchTypeNumLE, acl.MatchType_NUM_LE},
+	} {
+		require.Equal(t, tc.g, MatchTypeToGRPCField(tc.m), tc)
+		require.Equal(t, tc.m, MatchTypeFromGRPCField(tc.g), tc)
+	}
+}

--- a/object/convert_test.go
+++ b/object/convert_test.go
@@ -1,0 +1,28 @@
+package object
+
+import (
+	"testing"
+
+	object "github.com/nspcc-dev/neofs-api-go/v2/object/grpc"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMatchTypeToGRPCField(t *testing.T) {
+	for _, tc := range []struct {
+		m MatchType
+		g object.MatchType
+	}{
+		{MatchUnknown, object.MatchType_MATCH_TYPE_UNSPECIFIED},
+		{MatchStringEqual, object.MatchType_STRING_EQUAL},
+		{MatchStringNotEqual, object.MatchType_STRING_NOT_EQUAL},
+		{MatchNotPresent, object.MatchType_NOT_PRESENT},
+		{MatchCommonPrefix, object.MatchType_COMMON_PREFIX},
+		{MatchNumGT, object.MatchType_NUM_GT},
+		{MatchNumGE, object.MatchType_NUM_GE},
+		{MatchNumLT, object.MatchType_NUM_LT},
+		{MatchNumLE, object.MatchType_NUM_LE},
+	} {
+		require.Equal(t, tc.g, MatchTypeToGRPCField(tc.m), tc)
+		require.Equal(t, tc.m, MatchTypeFromGRPCField(tc.g), tc)
+	}
+}

--- a/object/types.go
+++ b/object/types.go
@@ -317,6 +317,10 @@ const (
 	MatchStringNotEqual
 	MatchNotPresent
 	MatchCommonPrefix
+	MatchNumGT
+	MatchNumGE
+	MatchNumLT
+	MatchNumLE
 )
 
 func (h *ShortHeader) GetVersion() *refs.Version {


### PR DESCRIPTION
Make codegen from https://github.com/nspcc-dev/neofs-api/commit/541cd3cd8d030b5670e7e247122395dfabaadeac.